### PR TITLE
west.yml: set clone-depth and add an import allowlist

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -9,4 +9,10 @@ manifest:
     - name: zephyr
       remote: zephyrproject-rtos
       revision: main
-      import: true
+      clone-depth: 1
+      import:
+        name-allowlist:
+          - cmsis
+          - hal_nxp
+          - hal_stm32
+          - segger


### PR DESCRIPTION
The current west setup imports every available module, an initial checkout takes forever. Set clone-depth: 1 so that modules get a shallow fetch by default (they can easily be unshallowed if needed) and add a list of modules instead of importing them all, initially just the NXP and STM32 one since those are the ones I know have USB+CAN, segger for RTT just in case.