### PR TITLE
github: workflows: run build workflow once a day

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build
 on:
   push:
   pull_request:
+  schedule:
+    - cron: "0 2 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
Since CANnectivity is currently tracking the Zephyr main branch change the build workflow to run once a day to catch any introduced incompatibilities.