### PR TITLE
README: add instructions for pulling in CANnectivity as a Zephyr module

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,23 @@ provided. These can be selected by setting either `FILE_SUFFIX=usbd_next` or
 `FILE_SUFFIX=usbd_next_release`.
 
 After building, the firmware can be flashed to the board by running the `west flash` command.
+
+## CANnectivity as a Zephyr Module
+
+The CANnectivity firmware repository is a [Zephyr
+module](https://docs.zephyrproject.org/latest/develop/modules.html) which allows for reuse of its
+components (i.e. the "gs_usb" protocol implementation) outside of the CANnectivity firmware
+application.
+
+To pull in CANnectivity as a Zephyr module, either add it as a West project in the `west.yaml` file
+or pull it in by adding a submanifest (e.g. `zephyr/submanifests/cannectivity.yaml`) file with the
+following content and run `west update`:
+
+```yaml
+manifest:
+  projects:
+    - name: cannectivity
+      url: https://github.com/CANnectivity/cannectivity.git
+      revision: main
+      path: custom/cannectivity # adjust the path as needed
+```


### PR DESCRIPTION
Add instructions for pulling in CANnectivity as a Zephyr module.