### PR TITLE
app: add optional firmware version boot banner

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -7,6 +7,13 @@ module = CANNECTIVITY
 module-str = CANnectivity
 source "subsys/logging/Kconfig.template.log_config"
 
+config CANNECTIVITY_BOOT_BANNER
+	bool "CANnectivity boot banner"
+	default y if BOOT_BANNER
+	select PRINTK
+	help
+	  Print the CANnectivity firmware version during boot up.
+
 config CANNECTIVITY_USB_MANUFACTURER
 	string "USB device manufacturer string"
 	default "CANnectivity"

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -12,6 +12,7 @@
 #include <cannectivity/usb/class/gs_usb.h>
 
 #include "cannectivity.h"
+#include "zephyr/app_version.h"
 
 LOG_MODULE_REGISTER(main, CONFIG_CANNECTIVITY_LOG_LEVEL);
 
@@ -43,6 +44,10 @@ int main(void)
 #endif /* !CANNECTIVITY_DT_HAS_CHANNEL */
 	};
 	int err;
+
+#ifdef CONFIG_CANNECTIVITY_BOOT_BANNER
+	printk("*** CANnectivity firmware version " APP_VERSION_STRING " ***\n");
+#endif /* CONFIG_CANNECTIVITY_BOOT_BANNER */
 
 	if (!device_is_ready(gs_usb)) {
 		LOG_ERR("gs_usb USB device not ready");


### PR DESCRIPTION
Add an optional boot banner showing the version of the CANnectivity firmware.