### PR TITLE
app: led: use correct log name

### DIFF
--- a/app/src/led.c
+++ b/app/src/led.c
@@ -13,7 +13,7 @@
 
 #include "cannectivity.h"
 
-LOG_MODULE_REGISTER(identify, CONFIG_CANNECTIVITY_LOG_LEVEL);
+LOG_MODULE_REGISTER(led, CONFIG_CANNECTIVITY_LOG_LEVEL);
 
 /* LED ticks */
 #define LED_TICK_MS        50U


### PR DESCRIPTION
Use correct log name in the led.c file. This file handles more than identify callbacks.