### PR TITLE
usb: device: gs_usb: make capturing hardware timestamp on sof optional

### DIFF
--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -16,6 +16,12 @@ tests:
       - frdm_k64f
       - lpcxpresso55s16
       - nucleo_h723zg
+  app.cannectivity.sof:
+    depends_on: usb_device can
+    integration_platforms:
+      - nucleo_h723zg
+    extra_configs:
+      - CONFIG_USB_DEVICE_GS_USB_TIMESTAMP_SOF=y
   app.cannectivity.release:
     depends_on: usb_device can
     extra_args:
@@ -31,6 +37,14 @@ tests:
     integration_platforms:
       - frdm_k64f
       - lpcxpresso55s16
+  app.cannectivity.usbd_next.sof:
+    depends_on: usbd can
+    extra_args:
+      - FILE_SUFFIX=usbd_next
+    integration_platforms:
+      - lpcxpresso55s16
+    extra_configs:
+      - CONFIG_USBD_GS_USB_TIMESTAMP_SOF=y
   app.cannectivity.usbd_next.release:
     depends_on: usbd can
     extra_args:

--- a/subsys/usb/device/class/Kconfig.gs_usb
+++ b/subsys/usb/device/class/Kconfig.gs_usb
@@ -43,9 +43,16 @@ config USB_DEVICE_GS_USB_IDENTIFICATION
 
 config USB_DEVICE_GS_USB_TIMESTAMP
 	bool "Enable support for hardware timestamps"
-	imply USB_DEVICE_SOF
 	help
 	  Enable support for hardware timestamps provided by the application.
+
+config USB_DEVICE_GS_USB_TIMESTAMP_SOF
+	bool "Capture hardware timestamp on USB SoF"
+	depends on USB_DEVICE_GS_USB_TIMESTAMP
+	select USB_DEVICE_SOF
+	help
+	  Capture the hardware timestamp on each USB Start of Frame event. This improves the
+	  timestamp accurracy with the cost of a higher CPU load.
 
 config USB_DEVICE_GS_USB_TERMINATION
 	bool "Enable support for CAN bus termination resistors"

--- a/subsys/usb/device_next/class/Kconfig.gs_usb
+++ b/subsys/usb/device_next/class/Kconfig.gs_usb
@@ -47,6 +47,13 @@ config USBD_GS_USB_TIMESTAMP
 	help
 	  Enable support for hardware timestamps provided by the application.
 
+config USBD_GS_USB_TIMESTAMP_SOF
+	bool "Capture hardware timestamp on USB SoF"
+	depends on USBD_GS_USB_TIMESTAMP
+	help
+	  Capture the hardware timestamp on each USB Start of Frame event. This improves the
+	  timestamp accurracy with the cost of a higher CPU load.
+
 config USBD_GS_USB_TERMINATION
 	bool "Enable support for CAN bus termination resistors"
 	help


### PR DESCRIPTION
Make the capturing of hardware timestamps on USB Start of Frame (SoF) events optional and disable it by default.

Capturing the hardware timestamp on SoF improves the accuracy of the time synchronization between the USB host and the device (in the range of ~110 to 20 microseconds depending on the board according to my measurements), but comes with a cost of much higher CPU load.

This does not affect the relative timestamping of CAN RX/TX frames, only their absolute timestamp as compared to the USB host time.