### PR TITLE
usb: device: class: gs_usb: update path to network buffer header file

### DIFF
--- a/subsys/usb/device/class/gs_usb.c
+++ b/subsys/usb/device/class/gs_usb.c
@@ -8,7 +8,7 @@
 #include <zephyr/drivers/can.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/net/buf.h>
+#include <zephyr/net_buf.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/usb/msos_desc.h>

--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -10,7 +10,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/net/buf.h>
+#include <zephyr/net_buf.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/usb/usbd.h>


### PR DESCRIPTION
Update the path to the network buffer header file, which was recently renamed in Zephyr main branch. Details in https://github.com/zephyrproject-rtos/zephyr/pull/78009