### PR TITLE
app: use newly granted USB VID:PID 1209:ca01 by default

### DIFF
--- a/99-cannectivity.rules
+++ b/99-cannectivity.rules
@@ -10,7 +10,7 @@
 ACTION!="add", SUBSYSTEM!="usb_device", GOTO="cannectivity_rules_end"
 
 # Replace VID and PID with CONFIG_CANNECTIVITY_USB_VID and CONFIG_CANNECTIVITY_USB_PID values
-ATTR{idVendor}=="1209", ATTR{idProduct}=="0001", RUN+="/sbin/modprobe -b gs_usb" MODE="660", GROUP="plugdev", TAG+="uaccess"
-SUBSYSTEM=="drivers", ENV{DEVPATH}=="/bus/usb/drivers/gs_usb", ATTR{new_id}="1209 0001"
+ATTR{idVendor}=="1209", ATTR{idProduct}=="ca01", RUN+="/sbin/modprobe -b gs_usb" MODE="660", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="drivers", ENV{DEVPATH}=="/bus/usb/drivers/gs_usb", ATTR{new_id}="1209 ca01"
 
 LABEL="cannectivity_rules_end"

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -34,7 +34,7 @@ config CANNECTIVITY_USB_VID
 
 config CANNECTIVITY_USB_PID
 	hex "USB device Product ID (PID)"
-	default 0x0001
+	default 0xca01
 	help
 	  CANnectivity USB device Product ID (PID).
 


### PR DESCRIPTION
Use USB VID:PID 1209:ca01 generously granted by pid.codes by default (see https://pid.codes/1209/CA01/).

PID was granted via https://github.com/pidcodes/pidcodes.github.com/pull/965