### PR TITLE
app: add console harness and run simple firmware boot test in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,14 @@ jobs:
           fi
           west twister -T app -v --inline-logs --integration $EXTRA_TWISTER_FLAGS
 
+      - name: Run firmware tests
+        working-directory: cannectivity
+        if: startsWith(runner.os, 'Linux')
+        shell: bash
+        run: |
+          # Limit to one concurrent instance as the USBIP port is reused between instances
+          west twister -T app -v --inline-logs --platform native_sim/native/64 -j1
+
       - name: Run tests
         working-directory: cannectivity
         shell: bash

--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -6,9 +6,13 @@ sample:
   name: cannectivity
 common:
   tags: usb can
-  build_only: true
   platform_exclude:
     - native_sim
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "CANnectivity firmware initialized with .*"
 tests:
   app.cannectivity:
     depends_on: usb_device can

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -86,4 +86,7 @@ int main(void)
 		LOG_ERR("failed to enable USB device");
 		return err;
 	}
+
+	LOG_INF("CANnectivity firmware initialized with %u channel%s\n", ARRAY_SIZE(channels),
+		ARRAY_SIZE(channels) > 1 ? "s" : "");
 }


### PR DESCRIPTION
Add console harness to the firmware application and run a simple boot test of the firmware application on native_sim in CI.
