### PR TITLE
github: dependabot: check for updates to python packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+  # Check for updates to Python packages
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Configure dependabot to check for updates to Python packages.