### PR TITLE
Make build excluded over all folders in the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@
 .venv
 
 # build
-/build*
 /twister-out*
+**/build*
 
 __pycache__/
 


### PR DESCRIPTION
Current /build* ignore pattern will exclude build only in the root of the project.
In some cases it is needed build folder to be located in app folder or anywhere else in the project.
This PR fixes this behaviour.

How to reporduce: Make west put build artefacts into <project root>/app/build folder or just move your folder there. You shall see git showing you about 500 untracked files.

UPDATE: This change allows efectivelly delete the whole build folder with `git clean -xdf`. Please still be carefull using this command anyway.