### PR TITLE
app: use newly granted USB VID:PID 1209:ca02 for DFU by default

### DIFF
--- a/99-cannectivity.rules
+++ b/99-cannectivity.rules
@@ -13,6 +13,9 @@ ACTION!="add", SUBSYSTEM!="usb_device", GOTO="cannectivity_rules_end"
 ATTR{idVendor}=="1209", ATTR{idProduct}=="ca01", RUN+="/sbin/modprobe -b gs_usb" MODE="660", GROUP="plugdev", TAG+="uaccess"
 SUBSYSTEM=="drivers", ENV{DEVPATH}=="/bus/usb/drivers/gs_usb", ATTR{new_id}="1209 ca01"
 
+# Replace VID and PID with SB_CONFIG_CANNECTIVITY_USB_DFU_VID and SB_CONFIG_CANNECTIVITY_USB_DFU_PID values
+ATTR{idVendor}=="1209", ATTR{idProduct}=="ca02", MODE="660", GROUP="plugdev", TAG+="uaccess"
+
 # Used for pytest suites
 ATTR{idVendor}=="1209", ATTR{idProduct}=="0001", MODE="660", GROUP="plugdev", TAG+="uaccess"
 

--- a/app/Kconfig.sysbuild
+++ b/app/Kconfig.sysbuild
@@ -29,7 +29,7 @@ config CANNECTIVITY_USB_DFU_VID
 
 config CANNECTIVITY_USB_DFU_PID
 	hex "USB DFU mode Product ID (PID)"
-	default 0x0001
+	default 0xca02
 	help
 	  CANnectivity USB DFU mode Product ID (PID).
 


### PR DESCRIPTION
Use USB VID:PID 1209:ca02 generously granted by pid.codes by for USB DFU mode by default (see https://pid.codes/1209/CA02/).