### PR TITLE
usb: device: class: gs_usb: use bulk EP max packet size to 512 for HS

### DIFF
--- a/subsys/usb/device/class/Kconfig.gs_usb
+++ b/subsys/usb/device/class/Kconfig.gs_usb
@@ -85,6 +85,7 @@ config USB_DEVICE_GS_USB_TX_THREAD_PRIO
 
 config USB_DEVICE_GS_USB_MAX_PACKET_SIZE
 	int "Maximum bulk endpoint packet size"
+	default 512 if USB_DC_HAS_HS_SUPPORT
 	default 64
 	range 64 512
 	help


### PR DESCRIPTION
Default to a max bulk endpoint packet size of 512 bytes if the USB device controller supports high-speed.