### PR TITLE
app + tests: remove use of space-separated lists

### DIFF
--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -5,7 +5,9 @@ sample:
   description: CANnectivity USB-to-CAN adapter firmware
   name: cannectivity
 common:
-  tags: usb can
+  tags:
+    - usb
+    - can
   platform_exclude:
     - native_sim
   harness: console
@@ -15,19 +17,25 @@ common:
       - "CANnectivity firmware initialized with .*"
 tests:
   app.cannectivity:
-    depends_on: usb_device can
+    depends_on:
+      - usb_device
+      - can
     integration_platforms:
       - frdm_k64f
       - lpcxpresso55s16
       - nucleo_h723zg
   app.cannectivity.sof:
-    depends_on: usb_device can
+    depends_on:
+      - usb_device
+      - can
     integration_platforms:
       - nucleo_h723zg
     extra_configs:
       - CONFIG_USB_DEVICE_GS_USB_TIMESTAMP_SOF=y
   app.cannectivity.release:
-    depends_on: usb_device can
+    depends_on:
+      - usb_device
+      - can
     extra_args:
       - FILE_SUFFIX=release
     integration_platforms:
@@ -35,14 +43,18 @@ tests:
       - lpcxpresso55s16
       - nucleo_h723zg
   app.cannectivity.usbd_next:
-    depends_on: usbd can
+    depends_on:
+      - usbd
+      - can
     extra_args:
       - FILE_SUFFIX=usbd_next
     integration_platforms:
       - frdm_k64f
       - lpcxpresso55s16
   app.cannectivity.usbd_next.sof:
-    depends_on: usbd can
+    depends_on:
+      - usbd
+      - can
     extra_args:
       - FILE_SUFFIX=usbd_next
     integration_platforms:
@@ -50,7 +62,9 @@ tests:
     extra_configs:
       - CONFIG_USBD_GS_USB_TIMESTAMP_SOF=y
   app.cannectivity.usbd_next.release:
-    depends_on: usbd can
+    depends_on:
+      - usbd
+      - can
     extra_args:
       - FILE_SUFFIX=usbd_next_release
     integration_platforms:
@@ -58,7 +72,9 @@ tests:
       - lpcxpresso55s16
   app.cannectivity.dfu:
     sysbuild: true
-    depends_on: usb_device can
+    depends_on:
+      - usb_device
+      - can
     platform_allow:
       - frdm_k64f
     extra_args: SB_CONF_FILE=sysbuild-dfu.conf

--- a/tests/subsys/usb/gs_usb/cxx/testcase.yaml
+++ b/tests/subsys/usb/gs_usb/cxx/testcase.yaml
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 common:
-  tags: usb can
+  tags:
+    - usb
+    - can
   depends_on: usb_device
   build_only: true
   integration_platforms:

--- a/tests/subsys/usb/gs_usb/host/testcase.yaml
+++ b/tests/subsys/usb/gs_usb/host/testcase.yaml
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 common:
-  tags: usb can
+  tags:
+    - usb
+    - can
   harness: pytest
   harness_config:
     pytest_dut_scope: session
@@ -11,11 +13,15 @@ common:
     - native_sim
 tests:
   usb.gs_usb.host:
-    depends_on: usb_device can
+    depends_on:
+      - usb_device
+      - can
     integration_platforms:
       - frdm_k64f/mk64f12
   usb.gs_usb.host.usbd_next:
-    depends_on: usbd can
+    depends_on:
+      - usbd
+      - can
     integration_platforms:
       - frdm_k64f/mk64f12
     extra_args:


### PR DESCRIPTION
Remove the use of space-separated lists, which was deprecated in Zephyr
v3.4.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>