### PR TITLE
README: do not restrict build status badge to pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="https://github.com/cannectivity/cannectivity/actions/workflows/build.yml?query=branch%3Amain">
-   <img src="https://github.com/cannectivity/cannectivity/actions/workflows/build.yml/badge.svg?event=push">
+   <img src="https://github.com/cannectivity/cannectivity/actions/workflows/build.yml/badge.svg">
 </a>
 
 # CANnectivity


### PR DESCRIPTION
Do not restrict the build status badge to builds triggered by pushes.