### PR TITLE
README: fix case for status badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<a href="https://github.com/cannectivity/cannectivity/actions/workflows/build.yml?query=branch%3Amain">
-   <img src="https://github.com/cannectivity/cannectivity/actions/workflows/build.yml/badge.svg">
+<a href="https://github.com/CANnectivity/cannectivity/actions/workflows/build.yml?query=branch%3Amain">
+   <img src="https://github.com/CANnectivity/cannectivity/actions/workflows/build.yml/badge.svg">
 </a>
 
 # CANnectivity


### PR DESCRIPTION
Fix the case for the status badge URLs. The GitHub mobile app treats these as case-sensitive.