### PR TITLE
Add support for dual (RX/TX) activity LEDs

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -69,6 +69,7 @@ config CANNECTIVITY_LED_GPIO
 	bool "LED support"
 	default y
 	depends on $(dt_compat_any_has_prop,cannectivity-channel,state-gpios) || \
+		   $(dt_compat_any_has_prop,cannectivity-channel,activity-gpios) || \
 		   ($(dt_alias_enabled,led0) && !$(dt_compat_enabled,cannectivity-channel))
 	select GPIO
 	select SMF

--- a/app/boards/usb2canfdv1_stm32g0b1xx.overlay
+++ b/app/boards/usb2canfdv1_stm32g0b1xx.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	cannectivity: cannectivity {
+		compatible = "cannectivity";
+		timestamp-counter = <&counter2>;
+
+		channel0 {
+			compatible = "cannectivity-channel";
+			can-controller = <&fdcan1>;
+			state-gpios = <&gpioa 2 GPIO_ACTIVE_LOW>;
+			activity-gpios = <&gpioa 0 GPIO_ACTIVE_LOW>,
+					 <&gpioa 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&zephyr_udc0 {
+	gs_usb0: gs_usb0 {
+		compatible = "gs_usb";
+	};
+};
+
+&timers2 {
+	status = "okay";
+	st,prescaler = <59>;
+
+	counter2: counter2 {
+		compatible = "st,stm32-counter";
+		status = "okay";
+	};
+};

--- a/app/dts/bindings/cannectivity.yaml
+++ b/app/dts/bindings/cannectivity.yaml
@@ -70,3 +70,6 @@ child-binding:
       description: |
         GPIO to use to control the CAN channel activity LED. This GPIO is driven active when the LED
         is to be turned on and inactive when the LED is to be turned off.
+
+        If two GPIOs are specified, the GPIO at index 0 will be used for indicating RX activity, and
+        the GPIO at index 1 will be used for indicating TX activity.

--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -24,6 +24,7 @@ tests:
       - frdm_k64f
       - lpcxpresso55s16
       - nucleo_h723zg
+      - usb2canfdv1
   app.cannectivity.sof:
     depends_on:
       - usb_device
@@ -51,6 +52,7 @@ tests:
     integration_platforms:
       - frdm_k64f
       - lpcxpresso55s16
+      - usb2canfdv1
   app.cannectivity.usbd_next.sof:
     depends_on:
       - usbd

--- a/app/src/led.c
+++ b/app/src/led.c
@@ -361,7 +361,9 @@ int cannectivity_led_event(const struct device *dev, uint16_t ch, enum gs_usb_ev
 		LOG_DBG("channel %u stopped", ch);
 		led_event = LED_EVENT_CHANNEL_STOPPED;
 		break;
-	case GS_USB_EVENT_CHANNEL_ACTIVITY:
+	case GS_USB_EVENT_CHANNEL_ACTIVITY_RX:
+		__fallthrough;
+	case GS_USB_EVENT_CHANNEL_ACTIVITY_TX:
 		/* low-pass filter activity events */
 		if (!sys_timepoint_expired(lctx->activity)) {
 			goto skipped;

--- a/include/cannectivity/usb/class/gs_usb.h
+++ b/include/cannectivity/usb/class/gs_usb.h
@@ -517,8 +517,10 @@ enum gs_usb_event {
 	GS_USB_EVENT_CHANNEL_STARTED,
 	/** Channel stopped. */
 	GS_USB_EVENT_CHANNEL_STOPPED,
-	/** Channel RX/TX activity. */
-	GS_USB_EVENT_CHANNEL_ACTIVITY,
+	/** Channel RX activity. */
+	GS_USB_EVENT_CHANNEL_ACTIVITY_RX,
+	/** Channel TX activity. */
+	GS_USB_EVENT_CHANNEL_ACTIVITY_TX,
 #if defined(CONFIG_USB_DEVICE_GS_USB_IDENTIFICATION) || defined(CONFIG_USBD_GS_USB_IDENTIFICATION)
 	/** Visual channel identification on. */
 	GS_USB_EVENT_CHANNEL_IDENTIFY_ON,

--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -1047,6 +1047,7 @@ static void gs_usb_rx_thread(void *p1, void *p2, void *p3)
 	struct gs_usb_data *data = dev->data;
 	struct gs_usb_host_frame_hdr *hdr;
 	struct gs_usb_channel_data *channel;
+	enum gs_usb_event event;
 	struct net_buf *buf;
 	struct udc_buf_info *bi;
 	uint32_t can_id;
@@ -1062,6 +1063,12 @@ static void gs_usb_rx_thread(void *p1, void *p2, void *p3)
 		hdr = (struct gs_usb_host_frame_hdr *)buf->data;
 		can_id = hdr->can_id;
 		ch = hdr->channel;
+
+		if (hdr->echo_id == GS_USB_HOST_FRAME_ECHO_ID_RX_FRAME) {
+			event = GS_USB_EVENT_CHANNEL_ACTIVITY_RX;
+		} else {
+			event = GS_USB_EVENT_CHANNEL_ACTIVITY_TX;
+		}
 
 		__ASSERT_NO_MSG(ch <= data->nchannels);
 		channel = &data->channels[ch];
@@ -1089,8 +1096,7 @@ static void gs_usb_rx_thread(void *p1, void *p2, void *p3)
 		}
 
 		if (data->ops.event != NULL) {
-			err = data->ops.event(dev, ch, GS_USB_EVENT_CHANNEL_ACTIVITY,
-					      data->user_data);
+			err = data->ops.event(dev, ch, event, data->user_data);
 			if (err != 0) {
 				LOG_ERR("activity callback for channel %u failed (err %d)", ch,
 					err);

--- a/tests/subsys/usb/gs_usb/host/src/main.c
+++ b/tests/subsys/usb/gs_usb/host/src/main.c
@@ -92,8 +92,13 @@ static int event_cb(const struct device *dev, uint16_t ch, enum gs_usb_event eve
 	case GS_USB_EVENT_CHANNEL_STOPPED:
 		LOG_DBG("dev = %s, ch = %u, started = 0, user_data = 0x%08x", dev->name, ch, ud);
 		break;
-	case GS_USB_EVENT_CHANNEL_ACTIVITY:
-		LOG_DBG("dev = %s, ch = %u, activity = 1, user_data = 0x%08x", dev->name, ch, ud);
+	case GS_USB_EVENT_CHANNEL_ACTIVITY_RX:
+		LOG_DBG("dev = %s, ch = %u, rx activity = 1, user_data = 0x%08x", dev->name, ch,
+			ud);
+		break;
+	case GS_USB_EVENT_CHANNEL_ACTIVITY_TX:
+		LOG_DBG("dev = %s, ch = %u, tx activity = 1, user_data = 0x%08x", dev->name, ch,
+			ud);
 		break;
 	case GS_USB_EVENT_CHANNEL_IDENTIFY_ON:
 		LOG_DBG("dev = %s, ch = %u, identify = 1, user_data = 0x%08x", dev->name, ch, ud);


### PR DESCRIPTION
- usb: device: class: gs_usb: split activity event into rx/tx activity
- app: handle LED activity in normal/started instead of a dedicated state
- app: add support for dual activity LEDs
- app: allow enabling LED support for boards with no state LED
- app: boards: add board overlay for the WeAct Studio USB2CANFDV1
- app: enable integration testing on the WeAct Studio USB2CANFDV1