### PR TITLE
Release CANnectivity v1.0.0 (tested against Zephyr v4.0.0)

### DIFF
--- a/app/VERSION
+++ b/app/VERSION
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION_MAJOR = 0
-VERSION_MINOR = 1
+VERSION_MAJOR = 1
+VERSION_MINOR = 0
 PATCHLEVEL = 0
 VERSION_TWEAK = 0
-EXTRAVERSION = dev
+EXTRAVERSION =

--- a/west.yml
+++ b/west.yml
@@ -8,7 +8,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: main
+      revision: v4.0-branch
       clone-depth: 1
       import:
         name-allowlist:


### PR DESCRIPTION
- The current version of CANnectivity was tested against Zephyr v4.0.0. Change the manifest to reflect this.
- Set the version to CANnectivity v1.0.0.
