### PR TITLE
app: remove empty line from log output

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -93,6 +93,6 @@ int main(void)
 		}
 	}
 
-	LOG_INF("CANnectivity firmware initialized with %u channel%s\n", ARRAY_SIZE(channels),
+	LOG_INF("CANnectivity firmware initialized with %u channel%s", ARRAY_SIZE(channels),
 		ARRAY_SIZE(channels) > 1 ? "s" : "");
 }


### PR DESCRIPTION
Log records should not include span over multiple lines.