### PR TITLE
usb: device: next: class: gs_usb: catch up with changes in Zephyr main branch

### DIFF
--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -1685,7 +1685,7 @@ struct usbd_class_api gs_usb_api = {
 	USBD_DEFINE_CLASS(gs_usb_##n, &gs_usb_api, (void *)DEVICE_DT_GET(DT_DRV_INST(n)),          \
 			  &gs_usb_vendor_requests);                                                \
                                                                                                    \
-	NET_BUF_POOL_FIXED_DEFINE(gs_usb_pool_##n, CONFIG_USBD_GS_USB_POOL_SIZE,                   \
+	UDC_BUF_POOL_DEFINE(gs_usb_pool_##n, CONFIG_USBD_GS_USB_POOL_SIZE,                         \
 				  GS_USB_HOST_FRAME_MAX_SIZE, sizeof(struct udc_buf_info), NULL);  \
                                                                                                    \
 	static struct gs_usb_data gs_usb_data_##n = {                                              \

--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -832,7 +832,6 @@ static struct net_buf *gs_usb_buf_alloc(struct gs_usb_data *data, uint8_t ep)
 	}
 
 	bi = udc_get_buf_info(buf);
-	memset(bi, 0, sizeof(struct udc_buf_info));
 	bi->ep = ep;
 
 	return buf;

--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -1539,8 +1539,6 @@ static int gs_usb_init(struct usbd_class_data *c_data)
 	struct gs_usb_data *data = dev->data;
 	struct gs_usb_desc *desc = data->desc;
 
-	desc->iad.bFirstInterface = desc->if0.bInterfaceNumber;
-
 	LOG_DBG("initialized class instance %p, interface number %u", c_data,
 		desc->iad.bFirstInterface);
 


### PR DESCRIPTION
- Use `NET_BUF_POOL_FIXED_DEFINE()` instead of `NET_BUF_POOL_FIXED_DEFINE()` to ensure UDC driver-compatible buffer alignment and granularity (https://github.com/zephyrproject-rtos/zephyr/pull/74021).
- usb: device: next: class: gs_usb: remove redundant interface assignment (https://github.com/zephyrproject-rtos/zephyr/pull/82600).
- usb: device: next: class: gs_usb: remove redundant `memset()` (https://github.com/zephyrproject-rtos/zephyr/pull/82961).