### PR TITLE
gs_usb: make dummy endpoint selectable by KConfig

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -46,6 +46,12 @@ config CANNECTIVITY_USB_MAX_POWER
 	  CANnectivity USB maximum current draw in milliampere (mA) divided by 2.
 	  A value of 125 results in a maximum current draw value of 250 mA.
 
+config CANNECTIVITY_USB_DUMMY_EP
+	bool "CANnectivity USB dummy endpoint select"
+	default y
+	help
+	  Enables dummy endpoint to support older gs_usb versions.
+
 if USB_DEVICE_STACK
 
 configdefault USB_DEVICE_MANUFACTURER

--- a/include/cannectivity/usb/class/gs_usb.h
+++ b/include/cannectivity/usb/class/gs_usb.h
@@ -466,10 +466,19 @@ struct gs_usb_host_frame_hdr {
 
 /** USB bulk IN endpoint address */
 #define GS_USB_IN_EP_ADDR    0x81
+#ifdef CONFIG_CANNECTIVITY_USB_DUMMY_EP
 /** USB (dummy) bulk OUT endpoint address */
 #define GS_USB_DUMMY_EP_ADDR 0x01
 /** USB bulk OUT endpoint address */
 #define GS_USB_OUT_EP_ADDR   0x02
+/** USB bulk total endpoints number */
+#define GS_USB_NUM_ENDPOINTS 3U
+#else
+/** USB bulk OUT endpoint address */
+#define GS_USB_OUT_EP_ADDR   0x01
+/** USB bulk total endpoints number */
+#define GS_USB_NUM_ENDPOINTS 2U
+#endif /* CONFIG_CANNECTIVITY_USB_DUMMY_EP */
 
 /** @} */
 

--- a/subsys/usb/device/class/gs_usb_device_define.h
+++ b/subsys/usb/device/class/gs_usb_device_define.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022-2024 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CANNECTIVITY_INCLUDE_GS_USB_DEVICE_DEFINE_H_
+#define CANNECTIVITY_INCLUDE_GS_USB_DEVICE_DEFINE_H_
+
+#define GS_USB_DEVICE_DEFINE(inst)                                                                 \
+	BUILD_ASSERT(DT_INST_ON_BUS(inst, usb),                                                    \
+		     "node " DT_NODE_PATH(                                                         \
+			     DT_DRV_INST(inst)) " is not assigned to a USB device controller");    \
+                                                                                                   \
+	NET_BUF_POOL_FIXED_DEFINE(gs_usb_pool_##inst, CONFIG_USB_DEVICE_GS_USB_POOL_SIZE,          \
+				  GS_USB_HOST_FRAME_MAX_SIZE, 0, NULL);                            \
+                                                                                                   \
+	USBD_CLASS_DESCR_DEFINE(primary, 0)                                                        \
+	struct gs_usb_config gs_usb_config_##inst = {                                              \
+		.iad = INITIALIZER_IAD,                                                            \
+		.if0 = INITIALIZER_IF,                                                             \
+		.if0_in_ep = INITIALIZER_IF_EP(GS_USB_IN_EP_ADDR),                                 \
+		.if0_out_ep = INITIALIZER_IF_EP(GS_USB_OUT_EP_ADDR),                               \
+	};                                                                                         \
+                                                                                                   \
+	static struct usb_ep_cfg_data gs_usb_ep_cfg_data_##inst[] = {                              \
+		{                                                                                  \
+			.ep_cb = usb_transfer_ep_callback,                                         \
+			.ep_addr = GS_USB_IN_EP_ADDR,                                              \
+		},                                                                                 \
+		{                                                                                  \
+			.ep_cb = usb_transfer_ep_callback,                                         \
+			.ep_addr = GS_USB_OUT_EP_ADDR,                                             \
+		},                                                                                 \
+	};                                                                                         \
+                                                                                                   \
+	USBD_DEFINE_CFG_DATA(gs_usb_cfg_##inst) = {                                                \
+		.usb_device_description = NULL,                                                    \
+		.interface_config = gs_usb_interface_config,                                       \
+		.interface_descriptor = &gs_usb_config_##inst.if0,                                 \
+		.cb_usb_status = gs_usb_status_callback,                                           \
+		.interface = {                                                                     \
+			.class_handler = NULL,                                                     \
+			.custom_handler = NULL,                                                    \
+			.vendor_handler = gs_usb_vendor_request_handler,                           \
+		},                                                                                 \
+		.num_endpoints = ARRAY_SIZE(gs_usb_ep_cfg_data_##inst),                            \
+		.endpoint = gs_usb_ep_cfg_data_##inst,                                             \
+	};                                                                                         \
+                                                                                                   \
+	static struct gs_usb_data gs_usb_data_##inst = {                                           \
+		.pool = &gs_usb_pool_##inst,                                                       \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, gs_usb_init, NULL, &gs_usb_data_##inst, &gs_usb_cfg_##inst,    \
+			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+
+#endif  /* CANNECTIVITY_INCLUDE_GS_USB_DEVICE_DEFINE_H_ */

--- a/subsys/usb/device/class/gs_usb_device_define_dummy.h
+++ b/subsys/usb/device/class/gs_usb_device_define_dummy.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022-2024 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CANNECTIVITY_INCLUDE_GS_USB_DEVICE_DEFINE_DUMMY_H_
+#define CANNECTIVITY_INCLUDE_GS_USB_DEVICE_DEFINE_DUMMY_H_
+
+#define GS_USB_DEVICE_DEFINE(inst)                                                                 \
+	BUILD_ASSERT(DT_INST_ON_BUS(inst, usb),                                                    \
+		     "node " DT_NODE_PATH(                                                         \
+			     DT_DRV_INST(inst)) " is not assigned to a USB device controller");    \
+                                                                                                   \
+	NET_BUF_POOL_FIXED_DEFINE(gs_usb_pool_##inst, CONFIG_USB_DEVICE_GS_USB_POOL_SIZE,          \
+				  GS_USB_HOST_FRAME_MAX_SIZE, 0, NULL);                            \
+                                                                                                   \
+	USBD_CLASS_DESCR_DEFINE(primary, 0)                                                        \
+	struct gs_usb_config gs_usb_config_##inst = {                                              \
+		.iad = INITIALIZER_IAD,                                                            \
+		.if0 = INITIALIZER_IF,                                                             \
+		.if0_in_ep = INITIALIZER_IF_EP(GS_USB_IN_EP_ADDR),                                 \
+		.if0_dummy_ep = INITIALIZER_IF_EP(GS_USB_DUMMY_EP_ADDR),                           \
+		.if0_out_ep = INITIALIZER_IF_EP(GS_USB_OUT_EP_ADDR),                               \
+	};                                                                                         \
+                                                                                                   \
+	static struct usb_ep_cfg_data gs_usb_ep_cfg_data_##inst[] = {                              \
+		{                                                                                  \
+			.ep_cb = usb_transfer_ep_callback,                                         \
+			.ep_addr = GS_USB_IN_EP_ADDR,                                              \
+		},                                                                                 \
+		{                                                                                  \
+			.ep_cb = usb_transfer_ep_callback,                                         \
+			.ep_addr = GS_USB_DUMMY_EP_ADDR,                                           \
+		},                                                                                 \
+		{                                                                                  \
+			.ep_cb = usb_transfer_ep_callback,                                         \
+			.ep_addr = GS_USB_OUT_EP_ADDR,                                             \
+		},                                                                                 \
+	};                                                                                         \
+                                                                                                   \
+	USBD_DEFINE_CFG_DATA(gs_usb_cfg_##inst) = {                                                \
+		.usb_device_description = NULL,                                                    \
+		.interface_config = gs_usb_interface_config,                                       \
+		.interface_descriptor = &gs_usb_config_##inst.if0,                                 \
+		.cb_usb_status = gs_usb_status_callback,                                           \
+		.interface = {                                                                     \
+			.class_handler = NULL,                                                     \
+			.custom_handler = NULL,                                                    \
+			.vendor_handler = gs_usb_vendor_request_handler,                           \
+		},                                                                                 \
+		.num_endpoints = ARRAY_SIZE(gs_usb_ep_cfg_data_##inst),                            \
+		.endpoint = gs_usb_ep_cfg_data_##inst,                                             \
+	};                                                                                         \
+                                                                                                   \
+	static struct gs_usb_data gs_usb_data_##inst = {                                           \
+		.pool = &gs_usb_pool_##inst,                                                       \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, gs_usb_init, NULL, &gs_usb_data_##inst, &gs_usb_cfg_##inst,    \
+			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+
+#endif  /* CANNECTIVITY_INCLUDE_GS_USB_DEVICE_DEFINE_DUMMY_H_ */

--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -28,10 +28,14 @@ struct gs_usb_desc {
 	struct usb_association_descriptor iad;
 	struct usb_if_descriptor if0;
 	struct usb_ep_descriptor if0_in_ep;
+#ifdef CONFIG_CANNECTIVITY_USB_DUMMY_EP
 	struct usb_ep_descriptor if0_dummy_ep;
+#endif /* CONFIG_CANNECTIVITY_USB_DUMMY_EP */
 	struct usb_ep_descriptor if0_out_ep;
 	struct usb_ep_descriptor if0_hs_in_ep;
+#ifdef CONFIG_CANNECTIVITY_USB_DUMMY_EP
 	struct usb_ep_descriptor if0_hs_dummy_ep;
+#endif /* CONFIG_CANNECTIVITY_USB_DUMMY_EP */
 	struct usb_ep_descriptor if0_hs_out_ep;
 	struct usb_desc_header nil_desc;
 };
@@ -1577,100 +1581,11 @@ struct usbd_class_api gs_usb_api = {
 	.init = gs_usb_init,
 };
 
-#define GS_USB_DEFINE_DESCRIPTOR(n)                                                                \
-	static struct gs_usb_desc gs_usb_desc_##n = {                                              \
-		.iad = {                                                                           \
-				.bLength = sizeof(struct usb_association_descriptor),              \
-				.bDescriptorType = USB_DESC_INTERFACE_ASSOC,                       \
-				.bFirstInterface = 0,                                              \
-				.bInterfaceCount = 1,                                              \
-				.bFunctionClass = USB_BCC_VENDOR,                                  \
-				.bFunctionSubClass = 0,                                            \
-				.bFunctionProtocol = 0,                                            \
-				.iFunction = 0,                                                    \
-		},                                                                                 \
-		.if0 = {                                                                           \
-				.bLength = sizeof(struct usb_if_descriptor),                       \
-				.bDescriptorType = USB_DESC_INTERFACE,                             \
-				.bInterfaceNumber = 0,                                             \
-				.bAlternateSetting = 0,                                            \
-				.bNumEndpoints = 3,                                                \
-				.bInterfaceClass = USB_BCC_VENDOR,                                 \
-				.bInterfaceSubClass = 0,                                           \
-				.bInterfaceProtocol = 0,                                           \
-				.iInterface = 0,                                                   \
-		},                                                                                 \
-		.if0_in_ep = {                                                                     \
-				.bLength = sizeof(struct usb_ep_descriptor),                       \
-				.bDescriptorType = USB_DESC_ENDPOINT,                              \
-				.bEndpointAddress = GS_USB_IN_EP_ADDR,                             \
-				.bmAttributes = USB_EP_TYPE_BULK,                                  \
-				.wMaxPacketSize = sys_cpu_to_le16(64),                             \
-				.bInterval = 0x00,                                                 \
-		},                                                                                 \
-		.if0_dummy_ep = {                                                                  \
-				.bLength = sizeof(struct usb_ep_descriptor),                       \
-				.bDescriptorType = USB_DESC_ENDPOINT,                              \
-				.bEndpointAddress = GS_USB_DUMMY_EP_ADDR,                          \
-				.bmAttributes = USB_EP_TYPE_BULK,                                  \
-				.wMaxPacketSize = sys_cpu_to_le16(64U),                            \
-				.bInterval = 0x00,                                                 \
-		},                                                                                 \
-		.if0_out_ep = {                                                                    \
-				.bLength = sizeof(struct usb_ep_descriptor),                       \
-				.bDescriptorType = USB_DESC_ENDPOINT,                              \
-				.bEndpointAddress = GS_USB_OUT_EP_ADDR,                            \
-				.bmAttributes = USB_EP_TYPE_BULK,                                  \
-				.wMaxPacketSize = sys_cpu_to_le16(64U),                            \
-				.bInterval = 0x00,                                                 \
-		},                                                                                 \
-		.if0_hs_in_ep = {                                                                  \
-				.bLength = sizeof(struct usb_ep_descriptor),                       \
-				.bDescriptorType = USB_DESC_ENDPOINT,                              \
-				.bEndpointAddress = GS_USB_IN_EP_ADDR,                             \
-				.bmAttributes = USB_EP_TYPE_BULK,                                  \
-				.wMaxPacketSize = sys_cpu_to_le16(512),                            \
-				.bInterval = 0x00,                                                 \
-		},                                                                                 \
-		.if0_hs_dummy_ep = {                                                               \
-				.bLength = sizeof(struct usb_ep_descriptor),                       \
-				.bDescriptorType = USB_DESC_ENDPOINT,                              \
-				.bEndpointAddress = GS_USB_DUMMY_EP_ADDR,                          \
-				.bmAttributes = USB_EP_TYPE_BULK,                                  \
-				.wMaxPacketSize = sys_cpu_to_le16(512U),                           \
-				.bInterval = 0x00,                                                 \
-		},                                                                                 \
-		.if0_hs_out_ep = {                                                                 \
-				.bLength = sizeof(struct usb_ep_descriptor),                       \
-				.bDescriptorType = USB_DESC_ENDPOINT,                              \
-				.bEndpointAddress = GS_USB_OUT_EP_ADDR,                            \
-				.bmAttributes = USB_EP_TYPE_BULK,                                  \
-				.wMaxPacketSize = sys_cpu_to_le16(512U),                           \
-				.bInterval = 0x00,                                                 \
-		},                                                                                 \
-		.nil_desc = {                                                                      \
-				.bLength = 0,                                                      \
-				.bDescriptorType = 0,                                              \
-		},                                                                                 \
-	};                                                                                         \
-                                                                                                   \
-	const static struct usb_desc_header *gs_usb_fs_desc_##n[] = {                              \
-		(struct usb_desc_header *)&gs_usb_desc_##n.iad,                                    \
-		(struct usb_desc_header *)&gs_usb_desc_##n.if0,                                    \
-		(struct usb_desc_header *)&gs_usb_desc_##n.if0_in_ep,                              \
-		(struct usb_desc_header *)&gs_usb_desc_##n.if0_dummy_ep,                           \
-		(struct usb_desc_header *)&gs_usb_desc_##n.if0_out_ep,                             \
-		(struct usb_desc_header *)&gs_usb_desc_##n.nil_desc,                               \
-	};                                                                                         \
-                                                                                                   \
-	const static struct usb_desc_header *gs_usb_hs_desc_##n[] = {                              \
-		(struct usb_desc_header *)&gs_usb_desc_##n.iad,                                    \
-		(struct usb_desc_header *)&gs_usb_desc_##n.if0,                                    \
-		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_in_ep,                           \
-		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_dummy_ep,                        \
-		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_out_ep,                          \
-		(struct usb_desc_header *)&gs_usb_desc_##n.nil_desc,                               \
-	}
+#ifdef CONFIG_CANNECTIVITY_USB_DUMMY_EP
+#include "gs_usb_define_descriptor_dummy.h"
+#else
+#include "gs_usb_define_descriptor.h"
+#endif  /* CONFIG_CANNECTIVITY_USB_DUMMY_EP */
 
 #define USBD_GS_USB_DT_DEVICE_DEFINE(n)                                                            \
 	BUILD_ASSERT(DT_INST_ON_BUS(n, usb),                                                       \

--- a/subsys/usb/device_next/class/gs_usb_define_descriptor.h
+++ b/subsys/usb/device_next/class/gs_usb_define_descriptor.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022-2024 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CANNECTIVITY_INCLUDE_GS_USB_DEFINE_DESCRIPTOR_H_
+#define CANNECTIVITY_INCLUDE_GS_USB_DEFINE_DESCRIPTOR_H_
+
+#define GS_USB_DEFINE_DESCRIPTOR(n)                                                                \
+	static struct gs_usb_desc gs_usb_desc_##n = {                                              \
+		.iad = {                                                                           \
+				.bLength = sizeof(struct usb_association_descriptor),              \
+				.bDescriptorType = USB_DESC_INTERFACE_ASSOC,                       \
+				.bFirstInterface = 0,                                              \
+				.bInterfaceCount = 1,                                              \
+				.bFunctionClass = USB_BCC_VENDOR,                                  \
+				.bFunctionSubClass = 0,                                            \
+				.bFunctionProtocol = 0,                                            \
+				.iFunction = 0,                                                    \
+		},                                                                                 \
+		.if0 = {                                                                           \
+				.bLength = sizeof(struct usb_if_descriptor),                       \
+				.bDescriptorType = USB_DESC_INTERFACE,                             \
+				.bInterfaceNumber = 0,                                             \
+				.bAlternateSetting = 0,                                            \
+				.bNumEndpoints = GS_USB_NUM_ENDPOINTS,                             \
+				.bInterfaceClass = USB_BCC_VENDOR,                                 \
+				.bInterfaceSubClass = 0,                                           \
+				.bInterfaceProtocol = 0,                                           \
+				.iInterface = 0,                                                   \
+		},                                                                                 \
+		.if0_in_ep = {                                                                     \
+				.bLength = sizeof(struct usb_ep_descriptor),                       \
+				.bDescriptorType = USB_DESC_ENDPOINT,                              \
+				.bEndpointAddress = GS_USB_IN_EP_ADDR,                             \
+				.bmAttributes = USB_EP_TYPE_BULK,                                  \
+				.wMaxPacketSize = sys_cpu_to_le16(64),                             \
+				.bInterval = 0x00,                                                 \
+		},                                                                                 \
+		.if0_out_ep = {                                                                    \
+				.bLength = sizeof(struct usb_ep_descriptor),                       \
+				.bDescriptorType = USB_DESC_ENDPOINT,                              \
+				.bEndpointAddress = GS_USB_OUT_EP_ADDR,                            \
+				.bmAttributes = USB_EP_TYPE_BULK,                                  \
+				.wMaxPacketSize = sys_cpu_to_le16(64U),                            \
+				.bInterval = 0x00,                                                 \
+		},                                                                                 \
+		.if0_hs_in_ep = {                                                                  \
+				.bLength = sizeof(struct usb_ep_descriptor),                       \
+				.bDescriptorType = USB_DESC_ENDPOINT,                              \
+				.bEndpointAddress = GS_USB_IN_EP_ADDR,                             \
+				.bmAttributes = USB_EP_TYPE_BULK,                                  \
+				.wMaxPacketSize = sys_cpu_to_le16(512),                            \
+				.bInterval = 0x00,                                                 \
+		},                                                                                 \
+		.if0_hs_out_ep = {                                                                 \
+				.bLength = sizeof(struct usb_ep_descriptor),                       \
+				.bDescriptorType = USB_DESC_ENDPOINT,                              \
+				.bEndpointAddress = GS_USB_OUT_EP_ADDR,                            \
+				.bmAttributes = USB_EP_TYPE_BULK,                                  \
+				.wMaxPacketSize = sys_cpu_to_le16(512U),                           \
+				.bInterval = 0x00,                                                 \
+		},                                                                                 \
+		.nil_desc = {                                                                      \
+				.bLength = 0,                                                      \
+				.bDescriptorType = 0,                                              \
+		},                                                                                 \
+	};                                                                                         \
+                                                                                                   \
+	const static struct usb_desc_header *gs_usb_fs_desc_##n[] = {                              \
+		(struct usb_desc_header *)&gs_usb_desc_##n.iad,                                    \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0,                                    \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_in_ep,                              \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_out_ep,                             \
+		(struct usb_desc_header *)&gs_usb_desc_##n.nil_desc,                               \
+	};                                                                                         \
+                                                                                                   \
+	const static struct usb_desc_header *gs_usb_hs_desc_##n[] = {                              \
+		(struct usb_desc_header *)&gs_usb_desc_##n.iad,                                    \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0,                                    \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_in_ep,                           \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_out_ep,                          \
+		(struct usb_desc_header *)&gs_usb_desc_##n.nil_desc,                               \
+	}
+
+#endif  /* CANNECTIVITY_INCLUDE_GS_USB_DEFINE_DESCRIPTOR_H_ */

--- a/subsys/usb/device_next/class/gs_usb_define_descriptor_dummy.h
+++ b/subsys/usb/device_next/class/gs_usb_define_descriptor_dummy.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022-2024 Alexander Kozhinov <ak.alexander.kozhinov@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CANNECTIVITY_INCLUDE_GS_USB_DEFINE_DESCRIPTOR_DUMMY_H_
+#define CANNECTIVITY_INCLUDE_GS_USB_DEFINE_DESCRIPTOR_DUMMY_H_
+
+#define GS_USB_DEFINE_DESCRIPTOR(n)                                                                \
+	static struct gs_usb_desc gs_usb_desc_##n = {                                              \
+		.iad = {                                                                           \
+				.bLength = sizeof(struct usb_association_descriptor),              \
+				.bDescriptorType = USB_DESC_INTERFACE_ASSOC,                       \
+				.bFirstInterface = 0,                                              \
+				.bInterfaceCount = 1,                                              \
+				.bFunctionClass = USB_BCC_VENDOR,                                  \
+				.bFunctionSubClass = 0,                                            \
+				.bFunctionProtocol = 0,                                            \
+				.iFunction = 0,                                                    \
+		},                                                                                 \
+		.if0 = {                                                                           \
+				.bLength = sizeof(struct usb_if_descriptor),                       \
+				.bDescriptorType = USB_DESC_INTERFACE,                             \
+				.bInterfaceNumber = 0,                                             \
+				.bAlternateSetting = 0,                                            \
+				.bNumEndpoints = 3,                                                \
+				.bInterfaceClass = USB_BCC_VENDOR,                                 \
+				.bInterfaceSubClass = 0,                                           \
+				.bInterfaceProtocol = 0,                                           \
+				.iInterface = 0,                                                   \
+		},                                                                                 \
+		.if0_in_ep = {                                                                     \
+				.bLength = sizeof(struct usb_ep_descriptor),                       \
+				.bDescriptorType = USB_DESC_ENDPOINT,                              \
+				.bEndpointAddress = GS_USB_IN_EP_ADDR,                             \
+				.bmAttributes = USB_EP_TYPE_BULK,                                  \
+				.wMaxPacketSize = sys_cpu_to_le16(64),                             \
+				.bInterval = 0x00,                                                 \
+		},                                                                                 \
+		.if0_dummy_ep = {                                                                  \
+				.bLength = sizeof(struct usb_ep_descriptor),                       \
+				.bDescriptorType = USB_DESC_ENDPOINT,                              \
+				.bEndpointAddress = GS_USB_DUMMY_EP_ADDR,                          \
+				.bmAttributes = USB_EP_TYPE_BULK,                                  \
+				.wMaxPacketSize = sys_cpu_to_le16(64U),                            \
+				.bInterval = 0x00,                                                 \
+		},                                                                                 \
+		.if0_out_ep = {                                                                    \
+				.bLength = sizeof(struct usb_ep_descriptor),                       \
+				.bDescriptorType = USB_DESC_ENDPOINT,                              \
+				.bEndpointAddress = GS_USB_OUT_EP_ADDR,                            \
+				.bmAttributes = USB_EP_TYPE_BULK,                                  \
+				.wMaxPacketSize = sys_cpu_to_le16(64U),                            \
+				.bInterval = 0x00,                                                 \
+		},                                                                                 \
+		.if0_hs_in_ep = {                                                                  \
+				.bLength = sizeof(struct usb_ep_descriptor),                       \
+				.bDescriptorType = USB_DESC_ENDPOINT,                              \
+				.bEndpointAddress = GS_USB_IN_EP_ADDR,                             \
+				.bmAttributes = USB_EP_TYPE_BULK,                                  \
+				.wMaxPacketSize = sys_cpu_to_le16(512),                            \
+				.bInterval = 0x00,                                                 \
+		},                                                                                 \
+		.if0_hs_dummy_ep = {                                                               \
+				.bLength = sizeof(struct usb_ep_descriptor),                       \
+				.bDescriptorType = USB_DESC_ENDPOINT,                              \
+				.bEndpointAddress = GS_USB_DUMMY_EP_ADDR,                          \
+				.bmAttributes = USB_EP_TYPE_BULK,                                  \
+				.wMaxPacketSize = sys_cpu_to_le16(512U),                           \
+				.bInterval = 0x00,                                                 \
+		},                                                                                 \
+		.if0_hs_out_ep = {                                                                 \
+				.bLength = sizeof(struct usb_ep_descriptor),                       \
+				.bDescriptorType = USB_DESC_ENDPOINT,                              \
+				.bEndpointAddress = GS_USB_OUT_EP_ADDR,                            \
+				.bmAttributes = USB_EP_TYPE_BULK,                                  \
+				.wMaxPacketSize = sys_cpu_to_le16(512U),                           \
+				.bInterval = 0x00,                                                 \
+		},                                                                                 \
+		.nil_desc = {                                                                      \
+				.bLength = 0,                                                      \
+				.bDescriptorType = 0,                                              \
+		},                                                                                 \
+	};                                                                                         \
+                                                                                                   \
+	const static struct usb_desc_header *gs_usb_fs_desc_##n[] = {                              \
+		(struct usb_desc_header *)&gs_usb_desc_##n.iad,                                    \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0,                                    \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_in_ep,                              \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_dummy_ep,                           \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_out_ep,                             \
+		(struct usb_desc_header *)&gs_usb_desc_##n.nil_desc,                               \
+	};                                                                                         \
+                                                                                                   \
+	const static struct usb_desc_header *gs_usb_hs_desc_##n[] = {                              \
+		(struct usb_desc_header *)&gs_usb_desc_##n.iad,                                    \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0,                                    \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_in_ep,                           \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_dummy_ep,                        \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_out_ep,                          \
+		(struct usb_desc_header *)&gs_usb_desc_##n.nil_desc,                               \
+	}
+
+#endif  /* CANNECTIVITY_INCLUDE_GS_USB_DEFINE_DESCRIPTOR_DUMMY_H_ */


### PR DESCRIPTION
This change adds dummy endpoint KConfig select flag to support dynamic endpoint enumeration made in
newer version of gs_usb driver in linux kernel.

Additional effect of this change is no need of
dummy usb endpoint at all if newer version of gs_usb driver is used.

Corresponding Linux Kernel driver change is listed in changelog: https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.5

@henrikbrixandersen In our discussion (https://github.com/CANnectivity/cannectivity/issues/24) you already mentioned working on similiar change, but I had to implement it to test my linux-kernel driver changes too.