### PR TITLE
app: boards: add support for the candlelightFD board

### DIFF
--- a/app/boards/candlelightfd_stm32g0b1xx.overlay
+++ b/app/boards/candlelightfd_stm32g0b1xx.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	cannectivity: cannectivity {
+		compatible = "cannectivity";
+		timestamp-counter = <&counter2>;
+
+		channel0 {
+			compatible = "cannectivity-channel";
+			can-controller = <&fdcan1>;
+			activity-gpios = <&gpioa 3 GPIO_ACTIVE_LOW>,
+					 <&gpioa 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&zephyr_udc0 {
+	gs_usb0: gs_usb0 {
+		compatible = "gs_usb";
+	};
+};
+
+&timers2 {
+	status = "okay";
+	st,prescaler = <59>;
+
+	counter2: counter2 {
+		compatible = "st,stm32-counter";
+		status = "okay";
+	};
+};

--- a/app/boards/candlelightfd_stm32g0b1xx_dual.conf
+++ b/app/boards/candlelightfd_stm32g0b1xx_dual.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_USB_DEVICE_GS_USB_MAX_CHANNELS=2

--- a/app/boards/candlelightfd_stm32g0b1xx_dual.overlay
+++ b/app/boards/candlelightfd_stm32g0b1xx_dual.overlay
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	cannectivity: cannectivity {
+		compatible = "cannectivity";
+		timestamp-counter = <&counter2>;
+
+		channel0 {
+			compatible = "cannectivity-channel";
+			can-controller = <&fdcan1>;
+			/* Use RX LED for channel 0 state + activity */
+			state-gpios = <&gpioa 3 GPIO_ACTIVE_LOW>;
+		};
+
+		channel1 {
+			compatible = "cannectivity-channel";
+			can-controller = <&fdcan2>;
+			/* Use TX LED for channel 0 state + activity */
+			state-gpios = <&gpioa 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&zephyr_udc0 {
+	gs_usb0: gs_usb0 {
+		compatible = "gs_usb";
+	};
+};
+
+&timers2 {
+	status = "okay";
+	st,prescaler = <59>;
+
+	counter2: counter2 {
+		compatible = "st,stm32-counter";
+		status = "okay";
+	};
+};

--- a/app/src/led.c
+++ b/app/src/led.c
@@ -68,8 +68,8 @@ struct led_ctx {
 #define CHANNEL_LED_GPIO_DT_SPEC_GET(node_id)                                                      \
 	{                                                                                          \
 		.state_led = GPIO_DT_SPEC_GET_OR(node_id, state_gpios, {0}),                       \
-		.activity_led = {DT_FOREACH_PROP_ELEM_SEP(node_id, activity_gpios,                 \
-							  GPIO_DT_SPEC_GET_BY_IDX, (,))},          \
+		.activity_led[0] = GPIO_DT_SPEC_GET_BY_IDX_OR(node_id, activity_gpios, 0, {0}),    \
+		.activity_led[1] = GPIO_DT_SPEC_GET_BY_IDX_OR(node_id, activity_gpios, 1, {0}),    \
 	}
 
 #define CHANNEL_LED0_GPIO_DT_SPEC_GET()                                                            \


### PR DESCRIPTION
Add support for the candlelightFD board from Linux Automation.
    
The board optionally supports a second CAN channel, but only provides two LEDs (RX/TX) in total. To work around this limitation, the "dual" configuration uses the RX LED for channel 0 state/activity, and the TX LED  for channel 1 state/activity.

Since this board has no activity LEDs in its dual configuration, add a small change to the LED initialisation code to support this.