### PR TITLE
usb: device: gs_usb: convert dummy endpoint to fully functional OUT ep

### DIFF
--- a/include/cannectivity/usb/class/gs_usb.h
+++ b/include/cannectivity/usb/class/gs_usb.h
@@ -458,18 +458,15 @@ struct gs_usb_host_frame_hdr {
 /**
  * @name USB endpoint addresses
  *
- * Existing drivers expect endpoints 0x81 and 0x02. Include a dummy endpoint 0x01 to work-around the
- * endpoint address fixup of the Zephyr USB device stack.
- *
  * @{
  */
 
 /** USB bulk IN endpoint address */
 #define GS_USB_IN_EP_ADDR    0x81
-/** USB (dummy) bulk OUT endpoint address */
-#define GS_USB_DUMMY_EP_ADDR 0x01
-/** USB bulk OUT endpoint address */
-#define GS_USB_OUT_EP_ADDR   0x02
+/** USB bulk OUT1 endpoint address */
+#define GS_USB_OUT1_EP_ADDR  0x01
+/** USB bulk OUT2 endpoint address */
+#define GS_USB_OUT2_EP_ADDR  0x02
 
 /** @} */
 

--- a/subsys/usb/device/class/Kconfig.gs_usb
+++ b/subsys/usb/device/class/Kconfig.gs_usb
@@ -92,4 +92,22 @@ config USB_DEVICE_GS_USB_MAX_PACKET_SIZE
 	  Maximum bulk endpoint packet size in bytes. Classic CAN host frames fit into 64 byte
 	  packets, whereas CAN FD host frames can benefit from a maximum packet size of 512 bytes.
 
+config USB_DEVICE_GS_USB_COMPATIBILITY_MODE
+	bool "Enable compatibility mode"
+	default y
+	help
+	  Enable Geschwister Schneider USB/CAN (gs_usb) driver compatibility mode.
+
+	  The Linux kernel gs_usb driver prior to kernel v6.12.5 uses hardcoded USB endpoint
+	  addresses 0x81 (bulk IN) and 0x02 (bulk OUT). The same assumption on USB endpoint
+	  addresses may be present in other drivers as well (e.g. python-can).
+
+	  Depending on the capabilities of the USB device controller, the requested USB endpoint
+	  addresses may be rewritten by the Zephyr USB device stack at runtime. Enabling
+	  compatibility mode will include a second bulk OUT endpoint to ensure correct operation
+	  with gs_usb drivers using the hardcoded USB endpoint addresses described above.
+
+	  It is safe to enable compatibility mode regardless of the driver being used, but the
+	  resulting firmware will require slightly more RAM and flash resources.
+
 endif # USB_DEVICE_GS_USB

--- a/subsys/usb/device_next/class/Kconfig.gs_usb
+++ b/subsys/usb/device_next/class/Kconfig.gs_usb
@@ -31,7 +31,8 @@ config USBD_GS_USB_MAX_CHANNELS
 
 config USBD_GS_USB_POOL_SIZE
 	int "Host frame buffer pool size"
-	default 20
+	default 20 if !USBD_GS_USB_COMPATIBILITY_MODE
+	default 21 if USBD_GS_USB_COMPATIBILITY_MODE
 	help
 	  Size of the pool used for allocating Geschwister Schneider USB/CAN (gs_usb) host
 	  frames. The pool is used for both RX and TX, and shared between all channels of a given
@@ -82,5 +83,23 @@ config USBD_GS_USB_TX_THREAD_PRIO
 	default 0
 	help
 	  Priority level for the internal TX thread.
+
+config USBD_GS_USB_COMPATIBILITY_MODE
+	bool "Enable compatibility mode"
+	default y
+	help
+	  Enable Geschwister Schneider USB/CAN (gs_usb) driver compatibility mode.
+
+	  The Linux kernel gs_usb driver prior to kernel v6.12.5 uses hardcoded USB endpoint
+	  addresses 0x81 (bulk IN) and 0x02 (bulk OUT). The same assumption on USB endpoint
+	  addresses may be present in other drivers as well (e.g. python-can).
+
+	  Depending on the capabilities of the USB device controller, the requested USB endpoint
+	  addresses may be rewritten by the Zephyr USB device stack at runtime. Enabling
+	  compatibility mode will include a second bulk OUT endpoint to ensure correct operation
+	  with gs_usb drivers using the hardcoded USB endpoint addresses described above.
+
+	  It is safe to enable compatibility mode regardless of the driver being used, but the
+	  resulting firmware will require slightly more RAM and flash resources.
 
 endif # USBD_GS_USB


### PR DESCRIPTION
Convert the dummy endpoint to a fully functional bulk OUT endpoint in order to be compatible with gs_usb drivers selecting the first available IN/OUT endpoints for use, and introduce a Kconfig option for turning off gs_usb driver compatibility mode.
    
The Linux kernel gs_usb driver prior to kernel v6.12.5 uses hardcoded USB endpoint addresses 0x81 (bulk IN) and 0x02 (bulk OUT). The same assumption on USB endpoint addresses may be present in other drivers as well (e.g. python-can).
    
Depending on the capabilities of the USB device controller, the requested USB endpoint addresses may be rewritten by the Zephyr USB device stack at runtime. Enabling compatibility mode will include a second bulk OUT endpoint to ensure correct operation with gs_usb drivers using the hardcoded USB endpoint addresses described above.
    
It is safe to enable compatibility mode regardless of the driver being used, but the resulting firmware will require slightly more RAM and flash resources.
