### PR TITLE
[Backport v1.0] app: remove empty line from log output

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -93,6 +93,6 @@ int main(void)
 		}
 	}
 
-	LOG_INF("CANnectivity firmware initialized with %u channel%s\n", ARRAY_SIZE(channels),
+	LOG_INF("CANnectivity firmware initialized with %u channel%s", ARRAY_SIZE(channels),
 		ARRAY_SIZE(channels) > 1 ? "s" : "");
 }


### PR DESCRIPTION
Remove tailing newline character from the log message. Logging should not span over multiple lines as it makes it harder to process automatically.

Signed-off-by: David Schneider <schneidav81@gmail.com>
(cherry picked from commit 42bbcd1cff9a89c96c88af6d26ce3b6707f2c454)