### PR TITLE
[Backport v1.0] usb: device: gs_usb: convert dummy endpoint to fully functional OUT ep

### DIFF
--- a/include/cannectivity/usb/class/gs_usb.h
+++ b/include/cannectivity/usb/class/gs_usb.h
@@ -458,18 +458,15 @@ struct gs_usb_host_frame_hdr {
 /**
  * @name USB endpoint addresses
  *
- * Existing drivers expect endpoints 0x81 and 0x02. Include a dummy endpoint 0x01 to work-around the
- * endpoint address fixup of the Zephyr USB device stack.
- *
  * @{
  */
 
 /** USB bulk IN endpoint address */
 #define GS_USB_IN_EP_ADDR    0x81
-/** USB (dummy) bulk OUT endpoint address */
-#define GS_USB_DUMMY_EP_ADDR 0x01
-/** USB bulk OUT endpoint address */
-#define GS_USB_OUT_EP_ADDR   0x02
+/** USB bulk OUT1 endpoint address */
+#define GS_USB_OUT1_EP_ADDR  0x01
+/** USB bulk OUT2 endpoint address */
+#define GS_USB_OUT2_EP_ADDR  0x02
 
 /** @} */
 

--- a/subsys/usb/device/class/Kconfig.gs_usb
+++ b/subsys/usb/device/class/Kconfig.gs_usb
@@ -92,4 +92,22 @@ config USB_DEVICE_GS_USB_MAX_PACKET_SIZE
 	  Maximum bulk endpoint packet size in bytes. Classic CAN host frames fit into 64 byte
 	  packets, whereas CAN FD host frames can benefit from a maximum packet size of 512 bytes.
 
+config USB_DEVICE_GS_USB_COMPATIBILITY_MODE
+	bool "Enable compatibility mode"
+	default y
+	help
+	  Enable Geschwister Schneider USB/CAN (gs_usb) driver compatibility mode.
+
+	  The Linux kernel gs_usb driver prior to kernel v6.12.5 uses hardcoded USB endpoint
+	  addresses 0x81 (bulk IN) and 0x02 (bulk OUT). The same assumption on USB endpoint
+	  addresses may be present in other drivers as well (e.g. python-can).
+
+	  Depending on the capabilities of the USB device controller, the requested USB endpoint
+	  addresses may be rewritten by the Zephyr USB device stack at runtime. Enabling
+	  compatibility mode will include a second bulk OUT endpoint to ensure correct operation
+	  with gs_usb drivers using the hardcoded USB endpoint addresses described above.
+
+	  It is safe to enable compatibility mode regardless of the driver being used, but the
+	  resulting firmware will require slightly more RAM and flash resources.
+
 endif # USB_DEVICE_GS_USB

--- a/subsys/usb/device_next/class/Kconfig.gs_usb
+++ b/subsys/usb/device_next/class/Kconfig.gs_usb
@@ -31,7 +31,8 @@ config USBD_GS_USB_MAX_CHANNELS
 
 config USBD_GS_USB_POOL_SIZE
 	int "Host frame buffer pool size"
-	default 20
+	default 20 if !USBD_GS_USB_COMPATIBILITY_MODE
+	default 21 if USBD_GS_USB_COMPATIBILITY_MODE
 	help
 	  Size of the pool used for allocating Geschwister Schneider USB/CAN (gs_usb) host
 	  frames. The pool is used for both RX and TX, and shared between all channels of a given
@@ -82,5 +83,23 @@ config USBD_GS_USB_TX_THREAD_PRIO
 	default 0
 	help
 	  Priority level for the internal TX thread.
+
+config USBD_GS_USB_COMPATIBILITY_MODE
+	bool "Enable compatibility mode"
+	default y
+	help
+	  Enable Geschwister Schneider USB/CAN (gs_usb) driver compatibility mode.
+
+	  The Linux kernel gs_usb driver prior to kernel v6.12.5 uses hardcoded USB endpoint
+	  addresses 0x81 (bulk IN) and 0x02 (bulk OUT). The same assumption on USB endpoint
+	  addresses may be present in other drivers as well (e.g. python-can).
+
+	  Depending on the capabilities of the USB device controller, the requested USB endpoint
+	  addresses may be rewritten by the Zephyr USB device stack at runtime. Enabling
+	  compatibility mode will include a second bulk OUT endpoint to ensure correct operation
+	  with gs_usb drivers using the hardcoded USB endpoint addresses described above.
+
+	  It is safe to enable compatibility mode regardless of the driver being used, but the
+	  resulting firmware will require slightly more RAM and flash resources.
 
 endif # USBD_GS_USB

--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -28,11 +28,11 @@ struct gs_usb_desc {
 	struct usb_association_descriptor iad;
 	struct usb_if_descriptor if0;
 	struct usb_ep_descriptor if0_in_ep;
-	struct usb_ep_descriptor if0_dummy_ep;
-	struct usb_ep_descriptor if0_out_ep;
+	struct usb_ep_descriptor if0_out1_ep;
+	struct usb_ep_descriptor if0_out2_ep;
 	struct usb_ep_descriptor if0_hs_in_ep;
-	struct usb_ep_descriptor if0_hs_dummy_ep;
-	struct usb_ep_descriptor if0_hs_out_ep;
+	struct usb_ep_descriptor if0_hs_out1_ep;
+	struct usb_ep_descriptor if0_hs_out2_ep;
 	struct usb_desc_header nil_desc;
 };
 
@@ -809,7 +809,7 @@ static uint8_t gs_usb_get_bulk_in_ep_addr(struct usbd_class_data *const c_data)
 	return desc->if0_in_ep.bEndpointAddress;
 }
 
-static uint8_t gs_usb_get_bulk_out_ep_addr(struct usbd_class_data *const c_data)
+static uint8_t gs_usb_get_bulk_out1_ep_addr(struct usbd_class_data *const c_data)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	const struct gs_usb_config *config = dev->config;
@@ -817,10 +817,24 @@ static uint8_t gs_usb_get_bulk_out_ep_addr(struct usbd_class_data *const c_data)
 	struct gs_usb_desc *desc = config->desc;
 
 	if (usbd_bus_speed(uds_ctx) == USBD_SPEED_HS) {
-		return desc->if0_hs_out_ep.bEndpointAddress;
+		return desc->if0_hs_out1_ep.bEndpointAddress;
 	}
 
-	return desc->if0_out_ep.bEndpointAddress;
+	return desc->if0_out1_ep.bEndpointAddress;
+}
+
+static uint8_t gs_usb_get_bulk_out2_ep_addr(struct usbd_class_data *const c_data)
+{
+	const struct device *dev = usbd_class_get_private(c_data);
+	const struct gs_usb_config *config = dev->config;
+	struct usbd_context *uds_ctx = usbd_class_get_ctx(c_data);
+	struct gs_usb_desc *desc = config->desc;
+
+	if (usbd_bus_speed(uds_ctx) == USBD_SPEED_HS) {
+		return desc->if0_hs_out2_ep.bEndpointAddress;
+	}
+
+	return desc->if0_out2_ep.bEndpointAddress;
 }
 
 static struct net_buf *gs_usb_buf_alloc(const struct gs_usb_config *config, uint8_t ep)
@@ -860,13 +874,12 @@ static void gs_usb_fill_echo_frame_hdr(struct net_buf *buf, uint32_t echo_id, ui
 	bi->ep = ep;
 }
 
-static int gs_usb_out_start(struct usbd_class_data *const c_data)
+static int gs_usb_out_start(struct usbd_class_data *const c_data, uint8_t ep)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	const struct gs_usb_config *config = dev->config;
 	struct gs_usb_data *data = dev->data;
 	struct net_buf *buf;
-	uint8_t ep;
 	int ret;
 
 	if (!atomic_test_bit(&data->state, GS_USB_STATE_CLASS_ENABLED)) {
@@ -874,16 +887,15 @@ static int gs_usb_out_start(struct usbd_class_data *const c_data)
 		return -EPERM;
 	}
 
-	ep = gs_usb_get_bulk_out_ep_addr(c_data);
 	buf = gs_usb_buf_alloc(config, ep);
 	if (buf == NULL) {
-		LOG_ERR("failed to allocate buffer for ep 0x%02x", ep);
+		LOG_ERR("failed to allocate buffer for OUT ep 0x%02x", ep);
 		return -ENOMEM;
 	}
 
 	ret = usbd_ep_enqueue(c_data, buf);
 	if (ret != 0) {
-		LOG_ERR("failed to enqueue buffer for ep 0x%02x (err %d)", ep, ret);
+		LOG_ERR("failed to enqueue buffer for OUT ep 0x%02x (err %d)", ep, ret);
 		net_buf_unref(buf);
 	}
 
@@ -1274,7 +1286,8 @@ static int gs_usb_request(struct usbd_class_data *const c_data, struct net_buf *
 
 	LOG_DBG("request complete for ep 0x%02x (err %d)", bi->ep, err);
 
-	if (bi->ep == gs_usb_get_bulk_out_ep_addr(c_data)) {
+	if (bi->ep == gs_usb_get_bulk_out1_ep_addr(c_data) ||
+	    bi->ep == gs_usb_get_bulk_out2_ep_addr(c_data)) {
 		if (!atomic_test_bit(&data->state, GS_USB_STATE_CLASS_ENABLED)) {
 			LOG_WRN("class not enabled");
 			net_buf_unref(buf);
@@ -1283,9 +1296,10 @@ static int gs_usb_request(struct usbd_class_data *const c_data, struct net_buf *
 
 		k_fifo_put(&data->tx_fifo, buf);
 
-		ret = gs_usb_out_start(c_data);
+		ret = gs_usb_out_start(c_data, bi->ep);
 		if (ret != 0) {
-			LOG_ERR("failed to restart OUT transfer (err %d)", ret);
+			LOG_ERR("failed to restart OUT transfer for ep 0x%02x (err %d)", bi->ep,
+				ret);
 		}
 
 		return ret;
@@ -1303,14 +1317,22 @@ static void gs_usb_enable(struct usbd_class_data *const c_data)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
 	struct gs_usb_data *data = dev->data;
+	uint8_t ep;
 	int err;
 
 	atomic_set_bit(&data->state, GS_USB_STATE_CLASS_ENABLED);
 	LOG_DBG("enabled");
 
-	err = gs_usb_out_start(c_data);
+	ep = gs_usb_get_bulk_out1_ep_addr(c_data);
+	err = gs_usb_out_start(c_data, ep);
 	if (err != 0) {
-		LOG_ERR("failed to start OUT transfer (err %d)", err);
+		LOG_ERR("failed to start OUT transfer for ep 0x%02x (err %d)", ep, err);
+	}
+
+	ep = gs_usb_get_bulk_out2_ep_addr(c_data);
+	err = gs_usb_out_start(c_data, ep);
+	if (err != 0) {
+		LOG_ERR("failed to start OUT transfer for ep 0x%02x (err %d)", ep, err);
 	}
 }
 
@@ -1335,7 +1357,13 @@ static void gs_usb_disable(struct usbd_class_data *const c_data)
 		LOG_ERR("failed to dequeue IN ep 0x%02x (err %d)", ep, err);
 	}
 
-	ep = gs_usb_get_bulk_out_ep_addr(c_data);
+	ep = gs_usb_get_bulk_out1_ep_addr(c_data);
+	err = usbd_ep_dequeue(uds_ctx, ep);
+	if (err != 0) {
+		LOG_ERR("failed to dequeue OUT ep 0x%02x (err %d)", ep, err);
+	}
+
+	ep = gs_usb_get_bulk_out2_ep_addr(c_data);
 	err = usbd_ep_dequeue(uds_ctx, ep);
 	if (err != 0) {
 		LOG_ERR("failed to dequeue OUT ep 0x%02x (err %d)", ep, err);
@@ -1619,18 +1647,18 @@ struct usbd_class_api gs_usb_api = {
 				.wMaxPacketSize = sys_cpu_to_le16(64),                             \
 				.bInterval = 0x00,                                                 \
 		},                                                                                 \
-		.if0_dummy_ep = {                                                                  \
+		.if0_out1_ep = {                                                                   \
 				.bLength = sizeof(struct usb_ep_descriptor),                       \
 				.bDescriptorType = USB_DESC_ENDPOINT,                              \
-				.bEndpointAddress = GS_USB_DUMMY_EP_ADDR,                          \
+				.bEndpointAddress = GS_USB_OUT1_EP_ADDR,                           \
 				.bmAttributes = USB_EP_TYPE_BULK,                                  \
 				.wMaxPacketSize = sys_cpu_to_le16(64U),                            \
 				.bInterval = 0x00,                                                 \
 		},                                                                                 \
-		.if0_out_ep = {                                                                    \
+		.if0_out2_ep = {                                                                   \
 				.bLength = sizeof(struct usb_ep_descriptor),                       \
 				.bDescriptorType = USB_DESC_ENDPOINT,                              \
-				.bEndpointAddress = GS_USB_OUT_EP_ADDR,                            \
+				.bEndpointAddress = GS_USB_OUT2_EP_ADDR,                           \
 				.bmAttributes = USB_EP_TYPE_BULK,                                  \
 				.wMaxPacketSize = sys_cpu_to_le16(64U),                            \
 				.bInterval = 0x00,                                                 \
@@ -1643,18 +1671,18 @@ struct usbd_class_api gs_usb_api = {
 				.wMaxPacketSize = sys_cpu_to_le16(512),                            \
 				.bInterval = 0x00,                                                 \
 		},                                                                                 \
-		.if0_hs_dummy_ep = {                                                               \
+		.if0_hs_out1_ep = {                                                                \
 				.bLength = sizeof(struct usb_ep_descriptor),                       \
 				.bDescriptorType = USB_DESC_ENDPOINT,                              \
-				.bEndpointAddress = GS_USB_DUMMY_EP_ADDR,                          \
+				.bEndpointAddress = GS_USB_OUT1_EP_ADDR,                           \
 				.bmAttributes = USB_EP_TYPE_BULK,                                  \
 				.wMaxPacketSize = sys_cpu_to_le16(512U),                           \
 				.bInterval = 0x00,                                                 \
 		},                                                                                 \
-		.if0_hs_out_ep = {                                                                 \
+		.if0_hs_out2_ep = {                                                                \
 				.bLength = sizeof(struct usb_ep_descriptor),                       \
 				.bDescriptorType = USB_DESC_ENDPOINT,                              \
-				.bEndpointAddress = GS_USB_OUT_EP_ADDR,                            \
+				.bEndpointAddress = GS_USB_OUT2_EP_ADDR,                           \
 				.bmAttributes = USB_EP_TYPE_BULK,                                  \
 				.wMaxPacketSize = sys_cpu_to_le16(512U),                           \
 				.bInterval = 0x00,                                                 \
@@ -1669,8 +1697,8 @@ struct usbd_class_api gs_usb_api = {
 		(struct usb_desc_header *)&gs_usb_desc_##n.iad,                                    \
 		(struct usb_desc_header *)&gs_usb_desc_##n.if0,                                    \
 		(struct usb_desc_header *)&gs_usb_desc_##n.if0_in_ep,                              \
-		(struct usb_desc_header *)&gs_usb_desc_##n.if0_dummy_ep,                           \
-		(struct usb_desc_header *)&gs_usb_desc_##n.if0_out_ep,                             \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_out1_ep,                            \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_out2_ep,                            \
 		(struct usb_desc_header *)&gs_usb_desc_##n.nil_desc,                               \
 	};                                                                                         \
                                                                                                    \
@@ -1678,8 +1706,8 @@ struct usbd_class_api gs_usb_api = {
 		(struct usb_desc_header *)&gs_usb_desc_##n.iad,                                    \
 		(struct usb_desc_header *)&gs_usb_desc_##n.if0,                                    \
 		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_in_ep,                           \
-		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_dummy_ep,                        \
-		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_out_ep,                          \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_out1_ep,                         \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_out2_ep,                         \
 		(struct usb_desc_header *)&gs_usb_desc_##n.nil_desc,                               \
 	}
 

--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -28,10 +28,14 @@ struct gs_usb_desc {
 	struct usb_association_descriptor iad;
 	struct usb_if_descriptor if0;
 	struct usb_ep_descriptor if0_in_ep;
+#ifdef CONFIG_USBD_GS_USB_COMPATIBILITY_MODE
 	struct usb_ep_descriptor if0_out1_ep;
+#endif /* CONFIG_USBD_GS_USB_COMPATIBILITY_MODE */
 	struct usb_ep_descriptor if0_out2_ep;
 	struct usb_ep_descriptor if0_hs_in_ep;
+#ifdef CONFIG_USBD_GS_USB_COMPATIBILITY_MODE
 	struct usb_ep_descriptor if0_hs_out1_ep;
+#endif /* CONFIG_USBD_GS_USB_COMPATIBILITY_MODE */
 	struct usb_ep_descriptor if0_hs_out2_ep;
 	struct usb_desc_header nil_desc;
 };
@@ -809,6 +813,7 @@ static uint8_t gs_usb_get_bulk_in_ep_addr(struct usbd_class_data *const c_data)
 	return desc->if0_in_ep.bEndpointAddress;
 }
 
+#ifdef CONFIG_USBD_GS_USB_COMPATIBILITY_MODE
 static uint8_t gs_usb_get_bulk_out1_ep_addr(struct usbd_class_data *const c_data)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
@@ -822,6 +827,7 @@ static uint8_t gs_usb_get_bulk_out1_ep_addr(struct usbd_class_data *const c_data
 
 	return desc->if0_out1_ep.bEndpointAddress;
 }
+#endif /* CONFIG_USBD_GS_USB_COMPATIBILITY_MODE */
 
 static uint8_t gs_usb_get_bulk_out2_ep_addr(struct usbd_class_data *const c_data)
 {
@@ -1286,8 +1292,12 @@ static int gs_usb_request(struct usbd_class_data *const c_data, struct net_buf *
 
 	LOG_DBG("request complete for ep 0x%02x (err %d)", bi->ep, err);
 
+#ifdef CONFIG_USBD_GS_USB_COMPATIBILITY_MODE
 	if (bi->ep == gs_usb_get_bulk_out1_ep_addr(c_data) ||
 	    bi->ep == gs_usb_get_bulk_out2_ep_addr(c_data)) {
+#else /* CONFIG_USBD_GS_USB_COMPATIBILITY_MODE */
+	if (bi->ep == gs_usb_get_bulk_out2_ep_addr(c_data)) {
+#endif /* CONFIG_USBD_GS_USB_COMPATIBILITY_MODE */
 		if (!atomic_test_bit(&data->state, GS_USB_STATE_CLASS_ENABLED)) {
 			LOG_WRN("class not enabled");
 			net_buf_unref(buf);
@@ -1323,11 +1333,13 @@ static void gs_usb_enable(struct usbd_class_data *const c_data)
 	atomic_set_bit(&data->state, GS_USB_STATE_CLASS_ENABLED);
 	LOG_DBG("enabled");
 
+#ifdef CONFIG_USBD_GS_USB_COMPATIBILITY_MODE
 	ep = gs_usb_get_bulk_out1_ep_addr(c_data);
 	err = gs_usb_out_start(c_data, ep);
 	if (err != 0) {
 		LOG_ERR("failed to start OUT transfer for ep 0x%02x (err %d)", ep, err);
 	}
+#endif /* CONFIG_USBD_GS_USB_COMPATIBILITY_MODE */
 
 	ep = gs_usb_get_bulk_out2_ep_addr(c_data);
 	err = gs_usb_out_start(c_data, ep);
@@ -1357,11 +1369,13 @@ static void gs_usb_disable(struct usbd_class_data *const c_data)
 		LOG_ERR("failed to dequeue IN ep 0x%02x (err %d)", ep, err);
 	}
 
+#ifdef CONFIG_USBD_GS_USB_COMPATIBILITY_MODE
 	ep = gs_usb_get_bulk_out1_ep_addr(c_data);
 	err = usbd_ep_dequeue(uds_ctx, ep);
 	if (err != 0) {
 		LOG_ERR("failed to dequeue OUT ep 0x%02x (err %d)", ep, err);
 	}
+#endif /* CONFIG_USBD_GS_USB_COMPATIBILITY_MODE */
 
 	ep = gs_usb_get_bulk_out2_ep_addr(c_data);
 	err = usbd_ep_dequeue(uds_ctx, ep);
@@ -1633,7 +1647,8 @@ struct usbd_class_api gs_usb_api = {
 				.bDescriptorType = USB_DESC_INTERFACE,                             \
 				.bInterfaceNumber = 0,                                             \
 				.bAlternateSetting = 0,                                            \
-				.bNumEndpoints = 3,                                                \
+				.bNumEndpoints =                                                   \
+				COND_CODE_1(CONFIG_USBD_GS_USB_COMPATIBILITY_MODE, (3), (2)),      \
 				.bInterfaceClass = USB_BCC_VENDOR,                                 \
 				.bInterfaceSubClass = 0,                                           \
 				.bInterfaceProtocol = 0,                                           \
@@ -1647,6 +1662,7 @@ struct usbd_class_api gs_usb_api = {
 				.wMaxPacketSize = sys_cpu_to_le16(64),                             \
 				.bInterval = 0x00,                                                 \
 		},                                                                                 \
+		IF_ENABLED(CONFIG_USBD_GS_USB_COMPATIBILITY_MODE, (                                \
 		.if0_out1_ep = {                                                                   \
 				.bLength = sizeof(struct usb_ep_descriptor),                       \
 				.bDescriptorType = USB_DESC_ENDPOINT,                              \
@@ -1654,7 +1670,7 @@ struct usbd_class_api gs_usb_api = {
 				.bmAttributes = USB_EP_TYPE_BULK,                                  \
 				.wMaxPacketSize = sys_cpu_to_le16(64U),                            \
 				.bInterval = 0x00,                                                 \
-		},                                                                                 \
+		},))                                                                               \
 		.if0_out2_ep = {                                                                   \
 				.bLength = sizeof(struct usb_ep_descriptor),                       \
 				.bDescriptorType = USB_DESC_ENDPOINT,                              \
@@ -1671,6 +1687,7 @@ struct usbd_class_api gs_usb_api = {
 				.wMaxPacketSize = sys_cpu_to_le16(512),                            \
 				.bInterval = 0x00,                                                 \
 		},                                                                                 \
+		IF_ENABLED(CONFIG_USBD_GS_USB_COMPATIBILITY_MODE, (                                \
 		.if0_hs_out1_ep = {                                                                \
 				.bLength = sizeof(struct usb_ep_descriptor),                       \
 				.bDescriptorType = USB_DESC_ENDPOINT,                              \
@@ -1678,7 +1695,7 @@ struct usbd_class_api gs_usb_api = {
 				.bmAttributes = USB_EP_TYPE_BULK,                                  \
 				.wMaxPacketSize = sys_cpu_to_le16(512U),                           \
 				.bInterval = 0x00,                                                 \
-		},                                                                                 \
+		},))                                                                               \
 		.if0_hs_out2_ep = {                                                                \
 				.bLength = sizeof(struct usb_ep_descriptor),                       \
 				.bDescriptorType = USB_DESC_ENDPOINT,                              \
@@ -1697,7 +1714,8 @@ struct usbd_class_api gs_usb_api = {
 		(struct usb_desc_header *)&gs_usb_desc_##n.iad,                                    \
 		(struct usb_desc_header *)&gs_usb_desc_##n.if0,                                    \
 		(struct usb_desc_header *)&gs_usb_desc_##n.if0_in_ep,                              \
-		(struct usb_desc_header *)&gs_usb_desc_##n.if0_out1_ep,                            \
+		IF_ENABLED(CONFIG_USBD_GS_USB_COMPATIBILITY_MODE, (                                \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_out1_ep,))                          \
 		(struct usb_desc_header *)&gs_usb_desc_##n.if0_out2_ep,                            \
 		(struct usb_desc_header *)&gs_usb_desc_##n.nil_desc,                               \
 	};                                                                                         \
@@ -1706,7 +1724,8 @@ struct usbd_class_api gs_usb_api = {
 		(struct usb_desc_header *)&gs_usb_desc_##n.iad,                                    \
 		(struct usb_desc_header *)&gs_usb_desc_##n.if0,                                    \
 		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_in_ep,                           \
-		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_out1_ep,                         \
+		IF_ENABLED(CONFIG_USBD_GS_USB_COMPATIBILITY_MODE, (                                \
+		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_out1_ep,))                       \
 		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_out2_ep,                         \
 		(struct usb_desc_header *)&gs_usb_desc_##n.nil_desc,                               \
 	}


### PR DESCRIPTION
Convert the dummy endpoint to a fully functional bulk OUT endpoint in order to be compatible with gs_usb drivers selecting the first available IN/OUT endpoints for use, and introduce a Kconfig option for turning off gs_usb driver compatibility mode.
    
The Linux kernel gs_usb driver prior to kernel v6.12.5 uses hardcoded USB endpoint addresses 0x81 (bulk IN) and 0x02 (bulk OUT). The same assumption on USB endpoint addresses may be present in other drivers as well (e.g. python-can).
    
Depending on the capabilities of the USB device controller, the requested USB endpoint addresses may be rewritten by the Zephyr USB device stack at runtime. Enabling compatibility mode will include a second bulk OUT endpoint to ensure correct operation with gs_usb drivers using the hardcoded USB endpoint addresses described above.
    
It is safe to enable compatibility mode regardless of the driver being used, but the resulting firmware will require slightly more RAM and flash resources.
