### PR TITLE
[Backport v1.0] app: src: led: fix state indication without activity LEDs

### DIFF
--- a/app/src/led.c
+++ b/app/src/led.c
@@ -167,14 +167,14 @@ static void led_indicate_activity(struct led_ctx *lctx, enum led_activity type, 
 
 	if (led == NULL && lctx->started && LED_CTX_HAS_STATE_LED(lctx)) {
 		led = &lctx->state_led;
-		value = !activity;
+		value = !value;
 	}
 
 	if (led != NULL) {
-		err = gpio_pin_set_dt(led, activity);
+		err = gpio_pin_set_dt(led, value);
 		if (err != 0) {
 			LOG_ERR("failed to turn %s channel %u activity LED (err %d)",
-				activity ? "on" : "off", lctx->ch, err);
+				value ? "on" : "off", lctx->ch, err);
 		}
 	}
 }


### PR DESCRIPTION
Fix CAN channel state indication when no CAN channel activity LEDs are present.

Fixes: a2794f9fefac5307fa59ffe91b64f386c2a1778b

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>
(cherry picked from commit 2ee71e1c570ac7c89c16cd2a84793600cc77a4fc)