### PR TITLE
app: led: represent LEDs as LEDs, not GPIOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The CANnectivity firmware supports the following features, some of which depend 
 - CAN FD (flexible data rate)
 - Fast-speed and Hi-speed USB
 - Multiple, independent CAN channels
-- GPIO-controlled LEDs:
+- LEDs:
   - CAN channel state LEDs
   - CAN channel activity LEDs
   - Visual CAN channel identification

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -20,7 +20,7 @@ target_sources(app PRIVATE
   src/usb.c
 )
 
-target_sources_ifdef(CONFIG_CANNECTIVITY_LED_GPIO app PRIVATE
+target_sources_ifdef(CONFIG_CANNECTIVITY_LED app PRIVATE
   src/led.c
 )
 

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -65,13 +65,13 @@ configdefault USB_MAX_POWER
 
 endif # USB_DEVICE_STACK
 
-config CANNECTIVITY_LED_GPIO
+config CANNECTIVITY_LED
 	bool "LED support"
 	default y
-	depends on $(dt_compat_any_has_prop,cannectivity-channel,state-gpios) || \
-		   $(dt_compat_any_has_prop,cannectivity-channel,activity-gpios) || \
+	depends on $(dt_compat_any_has_prop,cannectivity-channel,state-led) || \
+		   $(dt_compat_any_has_prop,cannectivity-channel,activity-leds) || \
 		   ($(dt_alias_enabled,led0) && !$(dt_compat_enabled,cannectivity-channel))
-	select GPIO
+	select LED
 	select SMF
 	select SMF_ANCESTOR_SUPPORT
 	select SMF_INITIAL_TRANSITION
@@ -79,9 +79,9 @@ config CANNECTIVITY_LED_GPIO
 	select USB_DEVICE_GS_USB_IDENTIFICATION if USB_DEVICE_GS_USB
 	select USBD_GS_USB_IDENTIFICATION if USBD_GS_USB
 	help
-	  Enable support for GPIO-controlled CAN channel status/activity LEDs.
+	  Enable support for CAN channel status/activity LEDs.
 
-if CANNECTIVITY_LED_GPIO
+if CANNECTIVITY_LED
 
 config CANNECTIVITY_LED_EVENT_MSGQ_SIZE
 	int "LED event message queue size"
@@ -101,7 +101,7 @@ config CANNECTIVITY_LED_THREAD_PRIO
 	help
 	  Priority level for the LED finite-state machine thread.
 
-endif # CANNECTIVITY_LED_GPIO
+endif # CANNECTIVITY_LED
 
 config CANNECTIVITY_TIMESTAMP_COUNTER
 	bool "Hardware timestamp support"
@@ -156,6 +156,7 @@ config CANNECTIVITY_DFU_LED
 	bool # hidden
 	default y
 	depends on $(dt_alias_enabled,mcuboot-led0)
+	select LED
 	help
 	  Enable support for controlling the Device Firmware Upgrade (DFU) LED (identified by the
 	  "mcuboot-led0" devicetree alias).

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -137,6 +137,7 @@ config CANNECTIVITY_DFU_BUTTON
 	bool "DFU button support"
 	default y
 	depends on $(dt_alias_enabled,mcuboot-button0)
+	select GPIO
 	select REBOOT
 	help
 	  Enable support for rebooting into Device Firmware Upgrade (DFU) mode by holding the DFU

--- a/app/boards/canbardo_same70n20b.overlay
+++ b/app/boards/canbardo_same70n20b.overlay
@@ -14,16 +14,16 @@
 			compatible = "cannectivity-channel";
 			can-controller = <&can0>;
 			termination-gpios = <&piod 1 GPIO_ACTIVE_HIGH>;
-			state-gpios = <&piod 22 GPIO_ACTIVE_LOW>;
-			activity-gpios = <&piod 24 GPIO_ACTIVE_LOW>;
+			state-led = <&can_0_ledg>;
+			activity-leds = <&can_0_ledy>;
 		};
 
 		channel1 {
 			compatible = "cannectivity-channel";
 			can-controller = <&can1>;
 			termination-gpios = <&piod 13 GPIO_ACTIVE_HIGH>;
-			state-gpios = <&piod 17 GPIO_ACTIVE_LOW>;
-			activity-gpios = <&piod 18 GPIO_ACTIVE_LOW>;
+			state-led = <&can_1_ledg>;
+			activity-leds = <&can_1_ledy>;
 		};
 	};
 };

--- a/app/boards/candlelight_stm32f072xb.overlay
+++ b/app/boards/candlelight_stm32f072xb.overlay
@@ -14,8 +14,7 @@
 		channel0 {
 			compatible = "cannectivity-channel";
 			can-controller = <&can1>;
-			activity-gpios = <&gpioa 0 GPIO_ACTIVE_LOW>,
-					 <&gpioa 1 GPIO_ACTIVE_LOW>;
+			activity-leds = <&led_rx &led_tx>;
 		};
 	};
 };

--- a/app/boards/candlelightfd_stm32g0b1xx.overlay
+++ b/app/boards/candlelightfd_stm32g0b1xx.overlay
@@ -14,8 +14,7 @@
 		channel0 {
 			compatible = "cannectivity-channel";
 			can-controller = <&fdcan1>;
-			activity-gpios = <&gpioa 3 GPIO_ACTIVE_LOW>,
-					 <&gpioa 4 GPIO_ACTIVE_LOW>;
+			activity-leds = <&led_rx &led_tx>;
 		};
 	};
 };

--- a/app/boards/candlelightfd_stm32g0b1xx_dual.overlay
+++ b/app/boards/candlelightfd_stm32g0b1xx_dual.overlay
@@ -15,14 +15,14 @@
 			compatible = "cannectivity-channel";
 			can-controller = <&fdcan1>;
 			/* Use RX LED for channel 0 state + activity */
-			state-gpios = <&gpioa 3 GPIO_ACTIVE_LOW>;
+			state-led = <&led_rx>;
 		};
 
 		channel1 {
 			compatible = "cannectivity-channel";
 			can-controller = <&fdcan2>;
 			/* Use TX LED for channel 0 state + activity */
-			state-gpios = <&gpioa 4 GPIO_ACTIVE_LOW>;
+			state-led = <&led_tx>;
 		};
 	};
 };

--- a/app/boards/lpcxpresso55s16_lpc55s16.overlay
+++ b/app/boards/lpcxpresso55s16_lpc55s16.overlay
@@ -15,8 +15,8 @@
 			compatible = "cannectivity-channel";
 			can-controller = <&can0>;
 			termination-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>; /* Red LED for testing */
-			state-gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
-			activity-gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
+			state-led = <&blue_led>;
+			activity-leds = <&green_led>;
 		};
 	};
 };

--- a/app/boards/mks_canable_v20_stm32g431xx.overlay
+++ b/app/boards/mks_canable_v20_stm32g431xx.overlay
@@ -14,8 +14,8 @@
 		channel0 {
 			compatible = "cannectivity-channel";
 			can-controller = <&fdcan1>;
-			state-gpios = <&gpioa 15 GPIO_ACTIVE_LOW>;  /* blue led */
-			activity-gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;  /* green led */
+			state-led = <&blue_led>;
+			activity-leds = <&green_led>;
 		};
 	};
 };

--- a/app/boards/native_sim.overlay
+++ b/app/boards/native_sim.overlay
@@ -7,6 +7,40 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
+	leds {
+		compatible = "gpio-leds";
+
+		led_ch0_state: led_ch0_state {
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			label = "Channel 0 state LED";
+		};
+
+		led_ch0_activity: led_ch0_activity {
+			gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+			label = "Channel 0 activity LED";
+		};
+
+		led_ch1_state: led_ch1_state {
+			gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+			label = "Channel 1 state LED";
+		};
+
+		led_ch1_activity: led_ch1_activity {
+			gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+			label = "Channel 1 activity LED";
+		};
+
+		led_ch2_state: led_ch2_state {
+			gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+			label = "Channel 2 state LED";
+		};
+
+		led_ch2_activity: led_ch2_activity {
+			gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+			label = "Channel 2 activity LED";
+		};
+	};
+
 	cannectivity: cannectivity {
 		compatible = "cannectivity";
 		timestamp-counter = <&counter0>;
@@ -15,24 +49,24 @@
 			compatible = "cannectivity-channel";
 			can-controller = <&can_loopback0>;
 			termination-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
-			state-gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
-			activity-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+			state-led = <&led_ch0_state>;
+			activity-leds = <&led_ch0_activity>;
 		};
 
 		channel1 {
 			compatible = "cannectivity-channel";
 			can-controller = <&can_loopback1>;
 			termination-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
-			state-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
-			activity-gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+			state-led = <&led_ch1_state>;
+			activity-leds = <&led_ch1_activity>;
 		};
 
 		channel2 {
 			compatible = "cannectivity-channel";
 			can-controller = <&can_loopback2>;
 			termination-gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
-			state-gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
-			activity-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+			state-led = <&led_ch2_state>;
+			activity-leds = <&led_ch2_activity>;
 		};
 	};
 

--- a/app/boards/nucleo_h723zg_stm32h723xx.overlay
+++ b/app/boards/nucleo_h723zg_stm32h723xx.overlay
@@ -14,8 +14,8 @@
 		channel0 {
 			compatible = "cannectivity-channel";
 			can-controller = <&fdcan1>;
-			state-gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
-			activity-gpios = <&gpioe 1 GPIO_ACTIVE_HIGH>;
+			state-led = <&green_led>;
+			activity-leds = <&yellow_led>;
 		};
 	};
 };

--- a/app/boards/ucan_stm32f072xb.overlay
+++ b/app/boards/ucan_stm32f072xb.overlay
@@ -14,8 +14,7 @@
 		channel0 {
 			compatible = "cannectivity-channel";
 			can-controller = <&can1>;
-			activity-gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>,
-					 <&gpioa 1 GPIO_ACTIVE_HIGH>;
+			activity-leds = <&led_rx &led_tx>;
 		};
 	};
 };

--- a/app/boards/usb2canfdv1_stm32g0b1xx.overlay
+++ b/app/boards/usb2canfdv1_stm32g0b1xx.overlay
@@ -14,9 +14,8 @@
 		channel0 {
 			compatible = "cannectivity-channel";
 			can-controller = <&fdcan1>;
-			state-gpios = <&gpioa 2 GPIO_ACTIVE_LOW>;
-			activity-gpios = <&gpioa 0 GPIO_ACTIVE_LOW>,
-					 <&gpioa 1 GPIO_ACTIVE_LOW>;
+			state-led = <&led_ready>;
+			activity-leds = <&led_rxd &led_txd>;
 		};
 	};
 };

--- a/app/dts/bindings/cannectivity.yaml
+++ b/app/dts/bindings/cannectivity.yaml
@@ -13,16 +13,16 @@ description: |
         compatible = "cannectivity-channel";
         can-controller = <&can0>;
         termination-gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
-        state-gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
-        activity-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+        state-led = <&ch0_state_led>;
+        activity-leds = <&ch0_activity_led>;
       };
 
       channel {
         compatible = "cannectivity-channel";
         can-controller = <&can1>;
         termination-gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
-        state-gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
-        activity-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+        state-led = <&ch1_state_led>;
+        activity-leds = <&ch1_activity_led>;
       };
     };
 
@@ -59,17 +59,15 @@ child-binding:
         active when the CAN termination is enabled and inactive when the CAN termination is
         disabled.
 
-    state-gpios:
-      type: phandle-array
+    state-led:
+      type: phandle
       description: |
-        GPIO to use to control the CAN channel state LED. This GPIO is driven active when
-        the LED is to be turned on and inactive when the LED is to be turned off.
+        Phandle for the CAN channel state LED.
 
-    activity-gpios:
-      type: phandle-array
+    activity-leds:
+      type: phandles
       description: |
-        GPIO to use to control the CAN channel activity LED. This GPIO is driven active when the LED
-        is to be turned on and inactive when the LED is to be turned off.
+        Phandle(s) for the CAN channel activity LED(s).
 
-        If two GPIOs are specified, the GPIO at index 0 will be used for indicating RX activity, and
-        the GPIO at index 1 will be used for indicating TX activity.
+        If two LED phandles are specified, the LED phandle at index 0 will be used for indicating RX
+        activity, and the LED phandle at index 1 will be used for indicating TX activity.

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -30,7 +30,7 @@ static const struct gs_usb_ops gs_usb_ops = {
 #ifdef CONFIG_CANNECTIVITY_TIMESTAMP_COUNTER
 	.timestamp = cannectivity_timestamp_get,
 #endif
-#ifdef CONFIG_CANNECTIVITY_LED_GPIO
+#ifdef CONFIG_CANNECTIVITY_LED
 	.event = cannectivity_led_event,
 #endif
 #ifdef CONFIG_CANNECTIVITY_TERMINATION_GPIO
@@ -60,7 +60,7 @@ int main(void)
 		return 0;
 	}
 
-	if (IS_ENABLED(CONFIG_CANNECTIVITY_LED_GPIO)) {
+	if (IS_ENABLED(CONFIG_CANNECTIVITY_LED)) {
 		err = cannectivity_led_init();
 		if (err != 0) {
 			return 0;

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -39,7 +39,7 @@ The CANnectivity firmware supports the following features, some of which depend 
 * CAN FD (flexible data rate)
 * Fast-speed and Hi-speed USB
 * Multiple, independent CAN channels
-* GPIO-controlled LEDs:
+* LEDs:
 
   * CAN channel state LEDs
   * CAN channel activity LEDs


### PR DESCRIPTION
Switch from representing LEDs as GPIOs to representing LEDs as LEDs:

- Rename the state-gpios/activity-gpios devicetree properties to state-led/activity-leds and use phandles to refer to existing LED devicetree nodes. This simplifies the CANnectivity firmware devicetree overlays and avoids having to repeat LED GPIO specifications already present in the board devicetree.
- Switch from using the Zephyr GPIO API for controlling LEDs to using the Zephyr LED API. This allows using LEDs controlled by a dedicated LED controller IP/external IC.

Suggested-by: @fabiobaltieri 