### PR TITLE
[Backport v1.0] app: dfu: CONFIG_CANNECTIVITY_DFU_BUTTON must select CONFIG_GPIO

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -137,6 +137,7 @@ config CANNECTIVITY_DFU_BUTTON
 	bool "DFU button support"
 	default y
 	depends on $(dt_alias_enabled,mcuboot-button0)
+	select GPIO
 	select REBOOT
 	help
 	  Enable support for rebooting into Device Firmware Upgrade (DFU) mode by holding the DFU


### PR DESCRIPTION
The Kconfig option CONFIG_CANNECTIVITY_DFU_BUTTON must select CONFIG_GPIO as the button is read using the Zephyr GPIO API.
    
Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>
(cherry picked from commit b11373facf30c7a7fa021b5cc507766bc2a64ed4)
