### PR TITLE
github: workflows: docs: only deploy documentation from main branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,13 @@
 name: Documentation
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+      - v*-branch
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
Only deploy documentation on pushes to the main branch.