### PR TITLE
doc: use intersphinx for linking to Zephyr documentation

### DIFF
--- a/doc/building.rst
+++ b/doc/building.rst
@@ -1,5 +1,5 @@
 ..
-  Copyright (c) 2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+  Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
   SPDX-License-Identifier: CC-BY-4.0
 
 :hide-toc:
@@ -8,7 +8,7 @@ Building and Running
 ====================
 
 Building the CANnectivity firmware requires a proper Zephyr development environment. Follow the
-official `Zephyr Getting Started Guide`_ to establish one.
+official Zephyr :external+zephyr:ref:`Getting Started Guide <getting_started>` to establish one.
 
 Once a proper Zephyr development environment is established, inialize the workspace folder (here
 ``my-workspace``). This will clone the CANnectivity firmware repository and download the necessary
@@ -44,11 +44,12 @@ After building, the firmware can be flashed to the board by running the ``west f
 USB Device Firmware Upgrade (DFU) Mode
 --------------------------------------
 
-CANnectivity supports USB Device Firmware Upgrade (`DFU`_) via the `MCUboot`_ bootloader. This is
-intended for use with boards without an on-board programmer.
+CANnectivity supports USB :external+zephyr:ref:`Device Firmware Upgrade <dfu>` (DFU) via the
+`MCUboot`_ bootloader. This is intended for use with boards without an on-board programmer.
 
-To build CANnectivity with MCUboot integration for USB DFU use `sysbuild`_ with the
-``sysbuild-dfu.conf`` configuration file when building for your board (here ``frdm_k64f``):
+To build CANnectivity with MCUboot integration for USB DFU use :external+zephyr:ref:`sysbuild
+<sysbuild>` with the ``sysbuild-dfu.conf`` configuration file when building for your board (here
+``frdm_k64f``):
 
 .. code-block:: console
 
@@ -71,17 +72,8 @@ Once in DFU mode, the CANnectivity firmware can be updated using
 
    dfu-util -a 1 -D build/app/zephyr/zephyr.signed.bin.dfu
 
-.. _Zephyr Getting Started Guide:
-   https://docs.zephyrproject.org/latest/getting_started/index.html
-
-.. _DFU:
-   https://docs.zephyrproject.org/latest/services/device_mgmt/dfu.html
-
 .. _MCUboot:
    https://www.trustedfirmware.org/projects/mcuboot/
-
-.. _sysbuild:
-   https://docs.zephyrproject.org/latest/build/sysbuild/index.html
 
 .. _dfu-util:
    https://dfu-util.sourceforge.net/

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+# Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 #
 # Configuration file for the Sphinx documentation builder
@@ -14,9 +14,12 @@ author = 'The CANnectivity Developers'
 extensions = [
     'sphinx_copybutton',
     'sphinx.ext.githubpages',
+    'sphinx.ext.intersphinx',
 ]
 
 exclude_patterns = ['build', 'Thumbs.db', '.DS_Store']
+
+intersphinx_mapping = {'zephyr': ('https://docs.zephyrproject.org/latest/', None)}
 
 html_baseurl = 'https://cannectivity.org/'
 html_title = 'CANnectivity USB to CAN adapter firmware'

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,5 +1,5 @@
 ..
-  Copyright (c) 2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+  Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
   SPDX-License-Identifier: CC-BY-4.0
 
 :hide-toc:

--- a/doc/module.rst
+++ b/doc/module.rst
@@ -1,5 +1,5 @@
 ..
-  Copyright (c) 2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+  Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
   SPDX-License-Identifier: CC-BY-4.0
 
 :hide-toc:
@@ -7,8 +7,9 @@
 Zephyr Module
 =============
 
-The CANnectivity firmware repository is a `Zephyr module`_ which allows for reuse of its components
-(i.e. the ``gs_usb`` protocol implementation) outside of the CANnectivity firmware application.
+The CANnectivity firmware repository is a :external+zephyr:ref:`Zephyr module <modules>` which
+allows for reuse of its components (i.e. the ``gs_usb`` protocol implementation) outside of the
+CANnectivity firmware application.
 
 To pull in CANnectivity as a Zephyr module, either add it as a West project in the ``west.yaml``
 file or pull it in by adding a submanifest (e.g. ``zephyr/submanifests/cannectivity.yaml``) file
@@ -22,6 +23,3 @@ with the following content and run ``west update``:
          url: https://github.com/CANnectivity/cannectivity.git
          revision: main
          path: custom/cannectivity # adjust the path as needed
-
-.. _Zephyr module:
-   https://docs.zephyrproject.org/latest/develop/modules.html

--- a/doc/porting.rst
+++ b/doc/porting.rst
@@ -1,5 +1,5 @@
 ..
-  Copyright (c) 2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+  Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
   SPDX-License-Identifier: CC-BY-4.0
 
 :hide-toc:
@@ -14,27 +14,20 @@ Since the CANnectivity firmware is based on the Zephyr RTOS, it requires Zephyr 
 board it is to run on. The board configuration must support both an USB device driver and at least
 one CAN controller.
 
-Check the list of `supported boards`_ in the Zephyr documentation to see if your board is already
-supported. If not, have a look at the instructions in the `board porting guide`_.
+Check the list of :external+zephyr:ref:`supported boards <boards>` in the Zephyr documentation to
+see if your board is already supported. If not, have a look at the instructions in the Zephyr
+:external+zephyr:ref:`Board Porting Guide <board_porting_guide>`.
 
 Board Configuration
 -------------------
 
-By default, CANnectivity relies on the `devicetree`_ ``zephyr,canbus`` chosen node property for
-specifying the CAN controller to use. If a devicetree alias for ``led0`` is present, it is used as
-status LED. This means that virtually any Zephyr board configuration supporting USB device, a CAN
-controller, and an optional user LED will work without any further configuration.
+By default, CANnectivity relies on the :external+zephyr:ref:`devicetree <devicetree>`
+``zephyr,canbus`` chosen node property for specifying the CAN controller to use. If a devicetree
+alias for ``led0`` is present, it is used as status LED. This means that virtually any Zephyr board
+configuration supporting USB device, a CAN controller, and an optional user LED will work without
+any further configuration.
 
 Advanced board configuration (e.g. multiple CAN controllers, multiple LEDs, hardware timestamp
 counter) is also supported via devicetree overlays. Check the description for the ``cannectivity``
 devicetree binding ``app/dts/bindings/cannectivity.yaml`` and the example devicetree overlays under
 ``app/boards/``.
-
-.. _supported boards:
-   https://docs.zephyrproject.org/latest/boards/index.html
-
-.. _board porting guide:
-   https://docs.zephyrproject.org/latest/hardware/porting/board_porting.html
-
-.. _devicetree:
-   https://docs.zephyrproject.org/latest/build/dts/index.html


### PR DESCRIPTION
Use the intersphinx extension for linking to Zephyr documentation instead of manually linking.