### PR TITLE
app: boards: include app.overlay in board overlays

### DIFF
--- a/app/boards/canbardo_same70n20b.overlay
+++ b/app/boards/canbardo_same70n20b.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
 
 / {
 	cannectivity: cannectivity {
@@ -25,12 +26,6 @@
 			state-led = <&can_1_ledg>;
 			activity-leds = <&can_1_ledy>;
 		};
-	};
-};
-
-&zephyr_udc0 {
-	gs_usb0: gs_usb0 {
-		compatible = "gs_usb";
 	};
 };
 

--- a/app/boards/candlelight_stm32f072xb.overlay
+++ b/app/boards/candlelight_stm32f072xb.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
 
 / {
 	cannectivity: cannectivity {
@@ -16,12 +17,6 @@
 			can-controller = <&can1>;
 			activity-leds = <&led_rx &led_tx>;
 		};
-	};
-};
-
-&zephyr_udc0 {
-	gs_usb0: gs_usb0 {
-		compatible = "gs_usb";
 	};
 };
 

--- a/app/boards/candlelightfd_stm32g0b1xx.overlay
+++ b/app/boards/candlelightfd_stm32g0b1xx.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
 
 / {
 	cannectivity: cannectivity {
@@ -16,12 +17,6 @@
 			can-controller = <&fdcan1>;
 			activity-leds = <&led_rx &led_tx>;
 		};
-	};
-};
-
-&zephyr_udc0 {
-	gs_usb0: gs_usb0 {
-		compatible = "gs_usb";
 	};
 };
 

--- a/app/boards/candlelightfd_stm32g0b1xx_dual.overlay
+++ b/app/boards/candlelightfd_stm32g0b1xx_dual.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
 
 / {
 	cannectivity: cannectivity {
@@ -24,12 +25,6 @@
 			/* Use TX LED for channel 0 state + activity */
 			state-led = <&led_tx>;
 		};
-	};
-};
-
-&zephyr_udc0 {
-	gs_usb0: gs_usb0 {
-		compatible = "gs_usb";
 	};
 };
 

--- a/app/boards/lpcxpresso55s16_lpc55s16.overlay
+++ b/app/boards/lpcxpresso55s16_lpc55s16.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
 
 / {
 	cannectivity: cannectivity {
@@ -18,12 +19,6 @@
 			state-led = <&blue_led>;
 			activity-leds = <&green_led>;
 		};
-	};
-};
-
-&zephyr_udc0 {
-	gs_usb0: gs_usb0 {
-		compatible = "gs_usb";
 	};
 };
 

--- a/app/boards/mks_canable_v20_stm32g431xx.overlay
+++ b/app/boards/mks_canable_v20_stm32g431xx.overlay
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
 
 / {
 	cannectivity: cannectivity {
@@ -17,12 +18,6 @@
 			state-led = <&blue_led>;
 			activity-leds = <&green_led>;
 		};
-	};
-};
-
-&zephyr_udc0 {
-	gs_usb0: gs_usb0 {
-		compatible = "gs_usb";
 	};
 };
 

--- a/app/boards/native_sim.overlay
+++ b/app/boards/native_sim.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
 
 / {
 	leds {
@@ -85,10 +86,4 @@
 		compatible = "zephyr,can-loopback";
 	};
 
-};
-
-&zephyr_udc0 {
-	gs_usb0: gs_usb0 {
-		compatible = "gs_usb";
-	};
 };

--- a/app/boards/nucleo_h723zg_stm32h723xx.overlay
+++ b/app/boards/nucleo_h723zg_stm32h723xx.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
 
 / {
 	cannectivity: cannectivity {
@@ -17,12 +18,6 @@
 			state-led = <&green_led>;
 			activity-leds = <&yellow_led>;
 		};
-	};
-};
-
-&zephyr_udc0 {
-	gs_usb0: gs_usb0 {
-		compatible = "gs_usb";
 	};
 };
 

--- a/app/boards/ucan_stm32f072xb.overlay
+++ b/app/boards/ucan_stm32f072xb.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
 
 / {
 	cannectivity: cannectivity {
@@ -16,12 +17,6 @@
 			can-controller = <&can1>;
 			activity-leds = <&led_rx &led_tx>;
 		};
-	};
-};
-
-&zephyr_udc0 {
-	gs_usb0: gs_usb0 {
-		compatible = "gs_usb";
 	};
 };
 

--- a/app/boards/usb2canfdv1_stm32g0b1xx.overlay
+++ b/app/boards/usb2canfdv1_stm32g0b1xx.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
 
 / {
 	cannectivity: cannectivity {
@@ -17,12 +18,6 @@
 			state-led = <&led_ready>;
 			activity-leds = <&led_rxd &led_txd>;
 		};
-	};
-};
-
-&zephyr_udc0 {
-	gs_usb0: gs_usb0 {
-		compatible = "gs_usb";
 	};
 };
 


### PR DESCRIPTION
Include the generic app.overlay in board-specific overlays instead of repeating the common configuration.