### PR TITLE
usb: class: gs_usb: add support for setting the interface descriptor str

### DIFF
--- a/app/app.overlay
+++ b/app/app.overlay
@@ -7,5 +7,6 @@
 &zephyr_udc0 {
 	gs_usb0: gs_usb0 {
 		compatible = "gs_usb";
+		label = "gs_usb";
 	};
 };

--- a/dts/bindings/usb/gs_usb.yaml
+++ b/dts/bindings/usb/gs_usb.yaml
@@ -5,4 +5,11 @@ description: Geschwister Schneider USB/CAN
 
 compatible: "gs_usb"
 
+include: base.yaml
+
 on-bus: usb
+
+properties:
+  label:
+    description: |
+      Optional string for use as the USB interface string descriptor.


### PR DESCRIPTION
Add support for setting the gs_usb class interface descriptor string (iInterface). The string can be set per instance via the devicetree label property.
    
The interface descriptor string can be used by host software for identifying the gs_usb class interface on composite USB devices.

Inspired-by: @fabiobaltieri in https://github.com/zephyrproject-rtos/zephyr/pull/84062