### PR TITLE
usb: device: class: gs_usb: remove interface association descriptor

### DIFF
--- a/app/src/usb.c
+++ b/app/src/usb.c
@@ -194,8 +194,7 @@ static int cannectivity_usb_init_usbd(void)
 			return err;
 		}
 
-		err = usbd_device_set_code_triple(&usbd, USBD_SPEED_HS, USB_BCC_MISCELLANEOUS, 0x02,
-						  0x01);
+		err = usbd_device_set_code_triple(&usbd, USBD_SPEED_HS, 0, 0, 0);
 		if (err != 0) {
 			LOG_ERR("failed to set high-speed code triple (err %d)", err);
 			return err;
@@ -220,7 +219,7 @@ static int cannectivity_usb_init_usbd(void)
 		return err;
 	}
 
-	err = usbd_device_set_code_triple(&usbd, USBD_SPEED_FS, USB_BCC_MISCELLANEOUS, 0x02, 0x01);
+	err = usbd_device_set_code_triple(&usbd, USBD_SPEED_FS, 0, 0, 0);
 	if (err != 0) {
 		LOG_ERR("failed to set full-speed code triple (err %d)", err);
 		return err;

--- a/subsys/usb/device/class/gs_usb.c
+++ b/subsys/usb/device/class/gs_usb.c
@@ -32,7 +32,6 @@ LOG_MODULE_REGISTER(gs_usb, CONFIG_USB_DEVICE_GS_USB_LOG_LEVEL);
 #endif /* !CONFIG_USB_DEVICE_GS_USB_COMPATIBILITY_MODE */
 
 struct gs_usb_config {
-	struct usb_association_descriptor iad;
 	struct usb_if_descriptor if0;
 	struct usb_ep_descriptor if0_in_ep;
 #ifdef CONFIG_USB_DEVICE_GS_USB_COMPATIBILITY_MODE
@@ -1461,12 +1460,10 @@ static void gs_usb_interface_config(struct usb_desc_header *head, uint8_t bInter
 
 	data = CONTAINER_OF(common, struct gs_usb_data, common);
 
-	desc->iad.bFirstInterface = bInterfaceNumber;
 	desc->if0.bInterfaceNumber = bInterfaceNumber;
 
 	if (data->if0_str_desc != NULL) {
 		idx = usb_get_str_descriptor_idx(data->if0_str_desc);
-		desc->iad.iFunction = idx;
 		desc->if0.iInterface = idx;
 	}
 }
@@ -1492,18 +1489,6 @@ static int gs_usb_init(const struct device *dev)
 
 	return 0;
 }
-
-#define INITIALIZER_IAD                                                                            \
-	{                                                                                          \
-		.bLength = sizeof(struct usb_association_descriptor),                              \
-		.bDescriptorType = USB_DESC_INTERFACE_ASSOC,                                       \
-		.bFirstInterface = 0,                                                              \
-		.bInterfaceCount = 0x01,                                                           \
-		.bFunctionClass = USB_BCC_VENDOR,                                                  \
-		.bFunctionSubClass = 0,                                                            \
-		.bFunctionProtocol = 0,                                                            \
-		.iFunction = 0,                                                                    \
-	}
 
 #define INITIALIZER_IF                                                                             \
 	{                                                                                          \
@@ -1553,7 +1538,6 @@ static int gs_usb_init(const struct device *dev)
                                                                                                    \
 	USBD_CLASS_DESCR_DEFINE(primary, 0)                                                        \
 	struct gs_usb_config gs_usb_config_##inst = {                                              \
-		.iad = INITIALIZER_IAD,                                                            \
 		.if0 = INITIALIZER_IF,                                                             \
 		.if0_in_ep = INITIALIZER_IF_EP(GS_USB_IN_EP_ADDR),                                 \
 		IF_ENABLED(CONFIG_USB_DEVICE_GS_USB_COMPATIBILITY_MODE,                            \

--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -25,7 +25,6 @@ LOG_MODULE_REGISTER(gs_usb, CONFIG_USBD_GS_USB_LOG_LEVEL);
 #define GS_USB_STATE_CLASS_ENABLED 0U
 
 struct gs_usb_desc {
-	struct usb_association_descriptor iad;
 	struct usb_if_descriptor if0;
 	struct usb_ep_descriptor if0_in_ep;
 #ifdef CONFIG_USBD_GS_USB_COMPATIBILITY_MODE
@@ -1592,14 +1591,13 @@ static int gs_usb_init(struct usbd_class_data *c_data)
 	int err;
 
 	LOG_DBG("initialized class instance %p, interface number %u", c_data,
-		desc->iad.bFirstInterface);
+		desc->if0.bInterfaceNumber);
 
 	if (config->if0_str_desc != NULL) {
 		err = usbd_add_descriptor(uds_ctx, config->if0_str_desc);
 		if (err != 0 && err != -EALREADY) {
 			LOG_ERR("failed to add interface string descriptor (err %d)", err);
 		} else {
-			desc->iad.iFunction = usbd_str_desc_get_idx(config->if0_str_desc);
 			desc->if0.iInterface = usbd_str_desc_get_idx(config->if0_str_desc);
 		}
 	}
@@ -1642,16 +1640,6 @@ struct usbd_class_api gs_usb_api = {
 
 #define GS_USB_DEFINE_DESCRIPTOR(n)                                                                \
 	static struct gs_usb_desc gs_usb_desc_##n = {                                              \
-		.iad = {                                                                           \
-				.bLength = sizeof(struct usb_association_descriptor),              \
-				.bDescriptorType = USB_DESC_INTERFACE_ASSOC,                       \
-				.bFirstInterface = 0,                                              \
-				.bInterfaceCount = 1,                                              \
-				.bFunctionClass = USB_BCC_VENDOR,                                  \
-				.bFunctionSubClass = 0,                                            \
-				.bFunctionProtocol = 0,                                            \
-				.iFunction = 0,                                                    \
-		},                                                                                 \
 		.if0 = {                                                                           \
 				.bLength = sizeof(struct usb_if_descriptor),                       \
 				.bDescriptorType = USB_DESC_INTERFACE,                             \
@@ -1721,7 +1709,6 @@ struct usbd_class_api gs_usb_api = {
 	};                                                                                         \
                                                                                                    \
 	static const struct usb_desc_header *gs_usb_fs_desc_##n[] = {                              \
-		(struct usb_desc_header *)&gs_usb_desc_##n.iad,                                    \
 		(struct usb_desc_header *)&gs_usb_desc_##n.if0,                                    \
 		(struct usb_desc_header *)&gs_usb_desc_##n.if0_in_ep,                              \
 		IF_ENABLED(CONFIG_USBD_GS_USB_COMPATIBILITY_MODE, (                                \
@@ -1731,7 +1718,6 @@ struct usbd_class_api gs_usb_api = {
 	};                                                                                         \
                                                                                                    \
 	static const struct usb_desc_header *gs_usb_hs_desc_##n[] = {                              \
-		(struct usb_desc_header *)&gs_usb_desc_##n.iad,                                    \
 		(struct usb_desc_header *)&gs_usb_desc_##n.if0,                                    \
 		(struct usb_desc_header *)&gs_usb_desc_##n.if0_hs_in_ep,                           \
 		IF_ENABLED(CONFIG_USBD_GS_USB_COMPATIBILITY_MODE, (                                \


### PR DESCRIPTION
Remove the unnecessary USB Interface Association Descriptor (IAD). The gs_usb device class has only one USB interface.