### PR TITLE
tests: usb: gs_usb: host: remove outdated comment

### DIFF
--- a/tests/subsys/usb/gs_usb/host/prj_usbd_next.conf
+++ b/tests/subsys/usb/gs_usb/host/prj_usbd_next.conf
@@ -1,7 +1,4 @@
 CONFIG_TEST=y
-# Some usbd_next drivers suffer from calling mutexes in ISR context. Disable asserts until fixed
-# upstream.
-#CONFIG_ASSERT=n
 
 CONFIG_LOG=y
 CONFIG_UDC_DRIVER_LOG_LEVEL_WRN=y


### PR DESCRIPTION
Remove outdated comment from the gs_usb host test configuration.