### PR TITLE
tests: usb: gs_usb: host: reflect that the class no longer uses IADs

### DIFF
--- a/tests/subsys/usb/gs_usb/host/src/usb.c
+++ b/tests/subsys/usb/gs_usb/host/src/usb.c
@@ -89,8 +89,7 @@ static int test_usb_init_usbd(void)
 			return err;
 		}
 
-		err = usbd_device_set_code_triple(&usbd, USBD_SPEED_HS, USB_BCC_MISCELLANEOUS, 0x02,
-						  0x01);
+		err = usbd_device_set_code_triple(&usbd, USBD_SPEED_HS, 0, 0, 0);
 		if (err != 0) {
 			LOG_ERR("failed to set high-speed code triple (err %d)", err);
 			return err;
@@ -115,7 +114,7 @@ static int test_usb_init_usbd(void)
 		return err;
 	}
 
-	err = usbd_device_set_code_triple(&usbd, USBD_SPEED_FS, USB_BCC_MISCELLANEOUS, 0x02, 0x01);
+	err = usbd_device_set_code_triple(&usbd, USBD_SPEED_FS, 0, 0, 0);
 	if (err != 0) {
 		LOG_ERR("failed to set full-speed code triple (err %d)", err);
 		return err;


### PR DESCRIPTION
Change the USB triplet of the gs_usb host test to (0, 0, 0) to reflect that the gs_usb class no longer uses an Interface Association Descriptor (IAD).

Fixes: 10a8cd4ae60f6bf15db11eed30a042a0d544912e