### PR TITLE
app: add support for indicating bus-powered vs. self-powered devices

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -38,6 +38,12 @@ config CANNECTIVITY_USB_PID
 	help
 	  CANnectivity USB device Product ID (PID).
 
+config CANNECTIVITY_USB_SELF_POWERED
+	bool "USB device is self-powered"
+	default y
+	help
+	  CANnectivity USB device is self-powered.
+
 config CANNECTIVITY_USB_MAX_POWER
 	int "USB device maximum power"
 	default 125
@@ -59,6 +65,9 @@ configdefault USB_DEVICE_VID
 
 configdefault USB_DEVICE_PID
 	default CANNECTIVITY_USB_PID
+
+configdefault USB_SELF_POWERED
+	default CANNECTIVITY_USB_SELF_POWERED
 
 configdefault USB_MAX_POWER
 	default CANNECTIVITY_USB_MAX_POWER

--- a/app/boards/canbardo_same70n20b.conf
+++ b/app/boards/canbardo_same70n20b.conf
@@ -1,5 +1,6 @@
 # Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
+CONFIG_CANNECTIVITY_USB_SELF_POWERED=n
 CONFIG_USB_DEVICE_GS_USB_COMPATIBILITY_MODE=n
 CONFIG_USB_DEVICE_GS_USB_MAX_CHANNELS=2

--- a/app/boards/candlelight_stm32f072xb.conf
+++ b/app/boards/candlelight_stm32f072xb.conf
@@ -1,4 +1,5 @@
-# Copyright (c) 2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+# Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
+CONFIG_CANNECTIVITY_USB_SELF_POWERED=n
 CONFIG_CAN_FD_MODE=n

--- a/app/boards/candlelightfd_stm32g0b1xx_dual.conf
+++ b/app/boards/candlelightfd_stm32g0b1xx_dual.conf
@@ -1,4 +1,5 @@
 # Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
+CONFIG_CANNECTIVITY_USB_SELF_POWERED=n
 CONFIG_USB_DEVICE_GS_USB_MAX_CHANNELS=2

--- a/app/boards/mks_canable_v20_stm32g431xx.conf
+++ b/app/boards/mks_canable_v20_stm32g431xx.conf
@@ -1,3 +1,8 @@
+# Copyright (c) 2025 Henrik Brix Andersen <henrik@brixandersen.dk>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CANNECTIVITY_USB_SELF_POWERED=n
+
 # The two lines below are needed to reduce flash usage
 CONFIG_LTO=y
 CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/app/boards/ucan_stm32f072xb.conf
+++ b/app/boards/ucan_stm32f072xb.conf
@@ -1,4 +1,5 @@
-# Copyright (c) 2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+# Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
+CONFIG_CANNECTIVITY_USB_SELF_POWERED=n
 CONFIG_CAN_FD_MODE=n

--- a/app/src/usb.c
+++ b/app/src/usb.c
@@ -133,8 +133,10 @@ USBD_DESC_SERIAL_NUMBER_DEFINE(sn);
 USBD_DESC_CONFIG_DEFINE(fs_config_desc, "Full-Speed Configuration");
 USBD_DESC_CONFIG_DEFINE(hs_config_desc, "High-Speed Configuration");
 
-USBD_CONFIGURATION_DEFINE(fs_config, 0U, CONFIG_CANNECTIVITY_USB_MAX_POWER, &fs_config_desc);
-USBD_CONFIGURATION_DEFINE(hs_config, 0U, CONFIG_CANNECTIVITY_USB_MAX_POWER, &hs_config_desc);
+static const uint8_t attr =
+	(IS_ENABLED(CONFIG_CANNECTIVITY_USB_SELF_POWERED) ? USB_SCD_SELF_POWERED : 0U);
+USBD_CONFIGURATION_DEFINE(fs_config, attr, CONFIG_CANNECTIVITY_USB_MAX_POWER, &fs_config_desc);
+USBD_CONFIGURATION_DEFINE(hs_config, attr, CONFIG_CANNECTIVITY_USB_MAX_POWER, &hs_config_desc);
 
 USBD_DESC_BOS_DEFINE(usbext, sizeof(bos_cap_lpm), &bos_cap_lpm);
 


### PR DESCRIPTION
- Add a Kconfig option for indicating that a CANnectivity USB device is self-powered (the default as this applies to most development boards where power is supplied via an onboard debugger).
- Disable CONFIG_CANNECTIVITY_USB_SELF_POWERED for bus-powered boards.