### PR TITLE
usb: device: class: gs_usb: get rid of "on-bus" devicetree requirement

### DIFF
--- a/app/app.overlay
+++ b/app/app.overlay
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2022-2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+ * Copyright (c) 2022-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&zephyr_udc0 {
+/ {
 	gs_usb0: gs_usb0 {
 		compatible = "gs_usb";
 		label = "gs_usb";

--- a/dts/bindings/usb/gs_usb.yaml
+++ b/dts/bindings/usb/gs_usb.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+# Copyright (c) 2022-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
 description: Geschwister Schneider USB/CAN
@@ -6,8 +6,6 @@ description: Geschwister Schneider USB/CAN
 compatible: "gs_usb"
 
 include: base.yaml
-
-on-bus: usb
 
 properties:
   label:

--- a/subsys/usb/device/class/gs_usb.c
+++ b/subsys/usb/device/class/gs_usb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+ * Copyright (c) 2022-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1515,10 +1515,6 @@ static int gs_usb_init(const struct device *dev)
 	}
 
 #define GS_USB_DEVICE_DEFINE(inst)                                                                 \
-	BUILD_ASSERT(DT_INST_ON_BUS(inst, usb),                                                    \
-		     "node " DT_NODE_PATH(                                                         \
-			     DT_DRV_INST(inst)) " is not assigned to a USB device controller");    \
-                                                                                                   \
 	NET_BUF_POOL_FIXED_DEFINE(gs_usb_pool_##inst, CONFIG_USB_DEVICE_GS_USB_POOL_SIZE,          \
 				  GS_USB_HOST_FRAME_MAX_SIZE, 0, NULL);                            \
                                                                                                    \

--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+ * Copyright (c) 2022-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1727,10 +1727,6 @@ struct usbd_class_api gs_usb_api = {
 	}
 
 #define USBD_GS_USB_DT_DEVICE_DEFINE(n)                                                            \
-	BUILD_ASSERT(DT_INST_ON_BUS(n, usb),                                                       \
-		     "node " DT_NODE_PATH(                                                         \
-			     DT_DRV_INST(n)) " is not assigned to a USB device controller");       \
-                                                                                                   \
 	GS_USB_DEFINE_DESCRIPTOR(n);                                                               \
                                                                                                    \
 	USBD_DEFINE_CLASS(gs_usb_##n, &gs_usb_api, (void *)DEVICE_DT_GET(DT_DRV_INST(n)),          \

--- a/tests/subsys/usb/gs_usb/cxx/app.overlay
+++ b/tests/subsys/usb/gs_usb/cxx/app.overlay
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+ * Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&zephyr_udc0 {
+/ {
 	gs_usb0: gs_usb0 {
 		compatible = "gs_usb";
 	};

--- a/tests/subsys/usb/gs_usb/host/app.overlay
+++ b/tests/subsys/usb/gs_usb/host/app.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+ * Copyright (c) 2022-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,9 +24,7 @@
 		status = "okay";
 		compatible = "zephyr,can-loopback";
 	};
-};
 
-&zephyr_udc0 {
 	gs_usb0: gs_usb0 {
 		compatible = "gs_usb";
 	};


### PR DESCRIPTION
Get rid of the "on-bus: usb" devicetree requirement to match upstream Zephyr USB class devicetree bindings.