### PR TITLE
udev: add note describing when these custom udev rules are needed

### DIFF
--- a/99-cannectivity.rules
+++ b/99-cannectivity.rules
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 #
+# NOTE: These udev rules are only strictly needed for Linux kernels prior to v6.15-rc1 and for
+#       running the CANnectivity test suites with user access.
+#
 # 1. Copy this file to /etc/udev/rules.d/99-cannectivity.rules
 #
 # 2. Activate the new rules by running the following commands:


### PR DESCRIPTION
The custom udev rules are strictly only needed for Linux kernels prior to v6.15-rc1 and when running the CANnectivity test suites (as they require user access to the USB devices).

Official Linux kernel driver support was added in the following commit: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=32f08b22f3b88b7ba43fa8f4090dfd9575343256