### PR TITLE
manifest: switch to cmsis_6

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -12,7 +12,7 @@ manifest:
       clone-depth: 1
       import:
         name-allowlist:
-          - cmsis
+          - cmsis_6
           - hal_atmel
           - hal_nxp
           - hal_stm32


### PR DESCRIPTION
Switch from the cmsis to the cmsis_6 module, which is now required for Cortex-M.