### PR TITLE
app: boards: fix configuration for usbd_next on candlelightfd//dual

### DIFF
--- a/app/boards/candlelightfd_stm32g0b1xx_dual_usbd_next.conf
+++ b/app/boards/candlelightfd_stm32g0b1xx_dual_usbd_next.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Henrik Brix Andersen <henrik@brixandersen.dk>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CANNECTIVITY_USB_SELF_POWERED=n
+CONFIG_USBD_GS_USB_MAX_CHANNELS=2

--- a/app/boards/candlelightfd_stm32g0b1xx_dual_usbd_next_release.conf
+++ b/app/boards/candlelightfd_stm32g0b1xx_dual_usbd_next_release.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Henrik Brix Andersen <henrik@brixandersen.dk>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CANNECTIVITY_USB_SELF_POWERED=n
+CONFIG_USBD_GS_USB_MAX_CHANNELS=2


### PR DESCRIPTION
Fix the Kconfig options for the dual-channel variant of the candleLightFD board.