### PR TITLE
usb: device: next: class: gs_usb: select UDC_ENABLE_SOF when needed

### DIFF
--- a/subsys/usb/device_next/class/Kconfig.gs_usb
+++ b/subsys/usb/device_next/class/Kconfig.gs_usb
@@ -51,6 +51,7 @@ config USBD_GS_USB_TIMESTAMP
 config USBD_GS_USB_TIMESTAMP_SOF
 	bool "Capture hardware timestamp on USB SoF"
 	depends on USBD_GS_USB_TIMESTAMP
+	select UDC_ENABLE_SOF
 	help
 	  Capture the hardware timestamp on each USB Start of Frame event. This improves the
 	  timestamp accurracy with the cost of a higher CPU load.


### PR DESCRIPTION
Select the newly introduced Kconfig CONFIG_UDC_ENABLE_SOF when timestamping on start-of-frame events is enabled.