### PR TITLE
usb: device: next: gs_usb: avoid double-free of net_buf

### DIFF
--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -1111,7 +1111,6 @@ static void gs_usb_rx_thread(void *p1, void *p2, void *p3)
 		}
 
 		k_sem_take(&data->in_sem, K_FOREVER);
-		net_buf_unref(buf);
 
 		if ((can_id & GS_USB_CAN_ID_FLAG_ERR) != 0U) {
 			/* Only indicate actual RX/TX activity, not error frames */


### PR DESCRIPTION
Avoid double-freeing the net_buf after successfully enqueuing it via usbd_ep_enqueue(). When this call succeeds, is is up the the USB device stack to free the passed net_buf.

(cherry picked from commit 73454f60553392f58876715a87a14bb1394441f0)