### PR TITLE
manifest: change manifest to track Zephyr v4.2-branch

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -8,7 +8,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: main
+      revision: v4.2-branch
       clone-depth: 1
       import:
         name-allowlist:


### PR DESCRIPTION
The current version of CANnectivity was tested against Zephyr v4.2.0. Change the manifest to reflect this.