### PR TITLE
app: add native_sim configuration for usbd_next

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@
 # build
 /twister-out*
 **/build*
+*.log
 
 __pycache__/

--- a/app/boards/native_sim_native_64_usbd_next.overlay
+++ b/app/boards/native_sim_native_64_usbd_next.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Henrik Brix Andersen <henrik@brixandersen.dk>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_sim_usbd_next.overlay"

--- a/app/boards/native_sim_usbd_next.overlay
+++ b/app/boards/native_sim_usbd_next.overlay
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
+
+/ {
+	leds {
+		compatible = "gpio-leds";
+
+		led_ch0_state: led_ch0_state {
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			label = "Channel 0 state LED";
+		};
+
+		led_ch0_activity: led_ch0_activity {
+			gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+			label = "Channel 0 activity LED";
+		};
+
+		led_ch1_state: led_ch1_state {
+			gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+			label = "Channel 1 state LED";
+		};
+
+		led_ch1_activity: led_ch1_activity {
+			gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+			label = "Channel 1 activity LED";
+		};
+
+		led_ch2_state: led_ch2_state {
+			gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+			label = "Channel 2 state LED";
+		};
+
+		led_ch2_activity: led_ch2_activity {
+			gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+			label = "Channel 2 activity LED";
+		};
+	};
+
+	cannectivity: cannectivity {
+		compatible = "cannectivity";
+		timestamp-counter = <&counter0>;
+
+		channel0 {
+			compatible = "cannectivity-channel";
+			can-controller = <&cannectivity0>;
+			termination-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			state-led = <&led_ch0_state>;
+			activity-leds = <&led_ch0_activity>;
+		};
+
+		channel1 {
+			compatible = "cannectivity-channel";
+			can-controller = <&cannectivity1>;
+			termination-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+			state-led = <&led_ch1_state>;
+			activity-leds = <&led_ch1_activity>;
+		};
+
+		channel2 {
+			compatible = "cannectivity-channel";
+			can-controller = <&cannectivity2>;
+			termination-gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
+			state-led = <&led_ch2_state>;
+			activity-leds = <&led_ch2_activity>;
+		};
+	};
+
+	cannectivity0: cannectivity0 {
+		status = "okay";
+		compatible = "zephyr,native-linux-can";
+		host-interface = "cannectivity0";
+	};
+
+	cannectivity1: cannectivity1 {
+		status = "okay";
+		compatible = "zephyr,native-linux-can";
+		host-interface = "cannectivity1";
+	};
+
+	cannectivity2: cannectivity2 {
+		status = "okay";
+		compatible = "zephyr,native-linux-can";
+		host-interface = "cannectivity2";
+	};
+
+};

--- a/scripts/cannectivity.conf
+++ b/scripts/cannectivity.conf
@@ -1,0 +1,14 @@
+# Copyright (c) 2025 Henrik Brix Andersen <henrik@brixandersen.dk>
+# SPDX-License-Identifier: Apache-2.0
+
+# Configuration file for net-tools/can-setup.sh
+
+modprobe vcan
+
+for i in $(seq 0 2); do
+    iface=cannectivity$i
+
+    echo "Adding vcan interface: $iface"
+    ip link add dev $iface type vcan
+    ip link set dev $iface up
+done

--- a/scripts/cannectivity.conf.stop
+++ b/scripts/cannectivity.conf.stop
@@ -1,0 +1,14 @@
+# Copyright (c) 2025 Henrik Brix Andersen <henrik@brixandersen.dk>
+# SPDX-License-Identifier: Apache-2.0
+
+# Configuration file for net-tools/can-setup.sh
+
+INTERFACE="$1"
+
+for i in $(seq 0 2); do
+    iface=cannectivity$i
+
+    echo "Deleting vcan interface: $iface"
+    ip link set $iface down
+    ip link delete $iface
+done

--- a/scripts/run-host-tests.sh
+++ b/scripts/run-host-tests.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env -S bash -e
+
+if [ -z "west list -f '{name}' | grep ^zephyr$" ]; then
+    ZEPHYR_DIR=$(west list -f '{abspath}' zephyr)
+else
+    # Assume zephyr is the manifest repo
+    ZEPHYR_DIR=$(west list -f '{abspath}' manifest)
+fi
+
+CANNECTIVITY_SCRIPTS_DIR=$(dirname $(realpath $0))
+NET_TOOLS_DIR=$(west list -f '{abspath}' net-tools)
+
+echo "Zephyr:    $ZEPHYR_DIR"
+echo "net-tools: $NET_TOOLS_DIR"
+
+cleanup() {
+    echo "Detaching USB/IP"
+    sudo usbip detach -p 0 || true
+
+    if [ -n "$CANNECTIVITY_PID" ]; then
+        echo "Stopping CANnectivity"
+        kill -SIGINT $CANNECTIVITY_PID || true
+    fi
+
+    if [ -n "$CANDUMP_PID" ]; then
+        echo "Stopping candump"
+        kill -SIGINT $CANDUMP_PID || true
+    fi
+
+    echo "Bringing down virtual CAN busses"
+    sudo $NET_TOOLS_DIR/can-setup.sh --config $CANNECTIVITY_SCRIPTS_DIR/cannectivity.conf down \
+        || true
+
+    echo "Bringing down network"
+    sudo $NET_TOOLS_DIR/net-setup.sh down || true
+}
+
+trap cleanup EXIT SIGINT
+
+echo "Bringing up network for USB/IP"
+# TODO: fix net-setup.sh up returning error 2
+sudo $NET_TOOLS_DIR/net-setup.sh up || true
+
+echo "Bringing up virtual CAN busses"
+sudo $NET_TOOLS_DIR/can-setup.sh --config $CANNECTIVITY_SCRIPTS_DIR/cannectivity.conf up
+
+echo "Starting candump"
+candump -t a -H any > host-tests-candump.log 2>&1 &
+CANDUMP_PID=$!
+
+echo "Building CANnectivity"
+west build -b native_sim/native/64 -S usbip-native-sim app -- -DFILE_SUFFIX=usbd_next
+
+echo "Starting CANnectivity"
+./build/zephyr/zephyr.exe > host-tests-cannectivity.log 2>&1 &
+CANNECTIVITY_PID=$!
+
+echo "Waiting for CANnectivity to start..."
+sleep 10
+
+echo "Attaching USB/IP"
+sudo modprobe vhci_hcd
+sudo usbip attach -r 192.0.2.1 -b 1-1
+
+echo "Waiting for USB/IP to attach..."
+sleep 10
+
+for i in `seq 0 2`; do
+    echo "Configuring CANnectivity CAN interface can$i"
+    sudo ip link set can$i type can bitrate 125000 fd on dbitrate 1000000
+    sudo ip link set can$i up
+done
+
+export CAN_INTERFACE=socketcan
+export CAN_CONFIG='{"fd": true}'
+
+for i in `seq 0 2`; do
+    echo "Testing CANnectivity CAN interface can$i"
+    export CAN_CHANNEL=can$i
+    sudo ip link property add dev cannectivity$i altname zcan0
+    west twister -T $ZEPHYR_DIR/tests/drivers/can/host/ -v --platform native_sim/native/64 -X can
+    sudo ip link property del dev cannectivity$i altname zcan0
+done

--- a/west.yml
+++ b/west.yml
@@ -18,3 +18,10 @@ manifest:
           - hal_stm32
           - mcuboot
           - segger
+    - name: net-tools
+      remote: zephyrproject-rtos
+      revision: 2750d71e28e48865a6fd8a10413f978bb216c59e
+      clone-depth: 1
+      path: tools/net-tools
+      groups:
+        - tools


### PR DESCRIPTION
- Add devicetree overlays for running CANnectivity on native_sim using USB/IP and SocketCAN.
-  Add script for running the Zephyr CAN host test suite using CANnectivity running in native_sim for providing the USB to CAN adapter.