### PR TITLE
github: restrict permissions to read and do not persist credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "0 2 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -18,6 +21,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           path: cannectivity
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,12 +9,17 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Restrict the GitHub workflows to read permissions and do not persist the credentials where not needed.