### PR TITLE
app + tests: do not exclude 32-bit native_sim

### DIFF
--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -8,8 +8,6 @@ common:
   tags:
     - can
     - usb
-  platform_exclude:
-    - native_sim
   harness: console
   harness_config:
     type: one_line

--- a/tests/subsys/usb/gs_usb/cxx/testcase.yaml
+++ b/tests/subsys/usb/gs_usb/cxx/testcase.yaml
@@ -8,9 +8,8 @@ common:
   depends_on: usb_device
   build_only: true
   integration_platforms:
-    - frdm_k64f
-  platform_exclude:
     - native_sim
+    - native_sim/native/64
 tests:
   usb.gs_usb.cxx98:
     extra_configs:

--- a/tests/subsys/usb/gs_usb/host/testcase.yaml
+++ b/tests/subsys/usb/gs_usb/host/testcase.yaml
@@ -9,8 +9,6 @@ common:
   harness_config:
     pytest_dut_scope: session
     fixture: usb
-  platform_exclude:
-    - native_sim
 tests:
   usb.gs_usb.host:
     depends_on:


### PR DESCRIPTION
Do not exclude the 32-bit native_sim platform when building.