### PR TITLE
[Backport v1.2] usb: device: next: gs_usb: add ep lookup in state change cb

### DIFF
--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -930,10 +930,12 @@ static void gs_usb_can_state_change_callback(const struct device *can_dev, enum 
 	struct gs_usb_host_frame_hdr hdr = {0};
 	uint8_t payload[8] = {0};
 	struct net_buf *buf;
+	uint8_t ep;
 
 	__ASSERT_NO_MSG(can_dev == channel->dev);
 
-	buf = net_buf_alloc_fixed(config->pool, K_NO_WAIT);
+	ep = gs_usb_get_bulk_in_ep_addr(config->c_data);
+	buf = gs_usb_buf_alloc(config, ep);
 	if (buf == NULL) {
 		LOG_ERR("failed to allocate error frame for channel %u", channel->ch);
 		k_sem_give(&channel->rx_overflows);


### PR DESCRIPTION
The endpoint address was not set (and therefore always 0x00) in the state change callback. I found this while trying to run Cannectivity on a nRF54H20-DK because I always got the error:

    <err> udc: Cannot enqueue to control OUT endpoint

when sending a command without being attached to a CAN bus.

The fix is just a copy of what you already do in the RX callback. Not sure if this is everything that needs to be done, but at least it seems to fix the issue for me.


(cherry picked from commit ff3d210642308da2604f35b4efb7f729fde38a6f)