### PR TITLE
app: boards: native_sim: switch to non-deprecated Kconfig for counter

### DIFF
--- a/app/boards/native_sim.conf
+++ b/app/boards/native_sim.conf
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+# Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_COUNTER_NATIVE_POSIX_FREQUENCY=1000000
+CONFIG_COUNTER_NATIVE_SIM_FREQUENCY=1000000

--- a/app/boards/native_sim_native_64.conf
+++ b/app/boards/native_sim_native_64.conf
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Henrik Brix Andersen <henrik@brixandersen.dk>
+# Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_COUNTER_NATIVE_POSIX_FREQUENCY=1000000
+CONFIG_COUNTER_NATIVE_SIM_FREQUENCY=1000000


### PR DESCRIPTION
Switch to using the non-deprecated Kconfig symbol for setting the native_sim counter frequency.