### PR TITLE
tests: usb: gs_usb: host: disable flexcan0 when testing on the frdm_k64f

### DIFF
--- a/tests/subsys/usb/gs_usb/host/boards/frdm_k64f_mk64f12.overlay
+++ b/tests/subsys/usb/gs_usb/host/boards/frdm_k64f_mk64f12.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Henrik Brix Andersen <henrik@brixandersen.dk>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../app.overlay"
+
+&flexcan0 {
+	status = "disabled";
+};


### PR DESCRIPTION
Disable FlexCAN instance 0 when doing integration testing on the NXP FRDM-K64F board.