### PR TITLE
github: workflows: docs: bump upload-artifact to v6

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           path: doc/build/html
 


### PR DESCRIPTION
Bump the upload-artifact action from v5 to v6.