### PR TITLE
github: workflows: docs: bump upload-artifact to v7

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           path: doc/build/html
 


### PR DESCRIPTION
Bump the upload-artifact action from v6 to v7.