### PR TITLE
app: boards: adds configuration for Makerbase MKS CANable V1.0

### DIFF
--- a/app/boards/mks_canable_v10_stm32f072xb.conf
+++ b/app/boards/mks_canable_v10_stm32f072xb.conf
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Navimatix GmbH
+# SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CANNECTIVITY_USB_SELF_POWERED=n
+CONFIG_CAN_FD_MODE=n
+CONFIG_CAN_STM32_BXCAN_MAX_STD_ID_FILTERS=1
+CONFIG_CAN_STM32_BXCAN_MAX_EXT_ID_FILTERS=1

--- a/app/boards/mks_canable_v10_stm32f072xb.overlay
+++ b/app/boards/mks_canable_v10_stm32f072xb.overlay
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Navimatix GmbH
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TiaC Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
+
+/ {
+	cannectivity: cannectivity {
+		compatible = "cannectivity";
+		timestamp-counter = <&counter2>;
+
+		channel0 {
+			compatible = "cannectivity-channel";
+			can-controller = <&can1>;
+			activity-leds = <&green_led &blue_led>;
+		};
+	};
+};
+
+&timers2 {
+	status = "okay";
+	st,prescaler = <47>;
+
+	counter2: counter2 {
+		compatible = "st,stm32-counter";
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Add configuration and DTS overlay for the _Makerbase MKS CANable V1.0_ board with reduced amount of supported filter entries and using an STM32 timer for time stamping.

It depends on zephyrproject-rtos/zephyr#104881 – thus why opened as draft.