### PR TITLE
usb: device: next: gs_usb: this class is no longer experimental

### DIFF
--- a/app/prj_usbd_next.conf
+++ b/app/prj_usbd_next.conf
@@ -1,5 +1,3 @@
-# This is using the experimental USB device_next stack class
-CONFIG_WARN_EXPERIMENTAL=y
 CONFIG_USB_DEVICE_STACK_NEXT=y
 
 # Logging configuration

--- a/app/prj_usbd_next_release.conf
+++ b/app/prj_usbd_next_release.conf
@@ -1,5 +1,3 @@
-# This is using the experimental USB device_next stack class
-CONFIG_WARN_EXPERIMENTAL=y
 CONFIG_USB_DEVICE_STACK_NEXT=y
 
 # Hardened configuration

--- a/subsys/usb/device_next/class/Kconfig.gs_usb
+++ b/subsys/usb/device_next/class/Kconfig.gs_usb
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config USBD_GS_USB
-	bool "Geschwister Schneider USB/CAN Device Class support [EXPERIMENTAL]"
+	bool "Geschwister Schneider USB/CAN Device Class support"
 	default y
 	depends on DT_HAS_GS_USB_ENABLED
-	select EXPERIMENTAL
 	select NET_BUF
 	select CAN
 	imply CAN_ACCEPT_RTR


### PR DESCRIPTION
The device_next gs_usb class implementation is no longer experimental.