### PR TITLE
github: workflows: docs: bump upload-pages-artifact to v5

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload pages artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: doc/build/html
 


### PR DESCRIPTION
Bump the upload-pages-artifact action from v4 to v5.