### PR TITLE
github: workflows: build: skip building on Windows for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2022]
+        exclude:
+          - os: windows-2022
+            if: github.event_name == 'pull_request'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Skip building on Windows for PRs as this is significantly slower than building on other OS'es.