### PR TITLE
github: workflows: docs: require hashes when installing Python deps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r doc/requirements.txt
+          pip install -r doc/requirements.txt --require-hashes
 
       - name: Build
         run: |


### PR DESCRIPTION
Require hashes when installing Python dependencies.