### PR TITLE
tests: usb: gs_usb: host: pytest: remove useless assignment

### DIFF
--- a/tests/subsys/usb/gs_usb/host/pytest/test_gs_usb.py
+++ b/tests/subsys/usb/gs_usb/host/pytest/test_gs_usb.py
@@ -40,8 +40,6 @@ class TestGsUsbRequests():
 
     def test_mode(self, dut, dev) -> None:
         """Test the mode request"""
-        mode = GsUSBDeviceMode(GsUSBCANChannelMode.RESET, GsUSBCANChannelFlag.NORMAL)
-
         for ch in FAKE_CHANNELS:
             mode = GsUSBDeviceMode(GsUSBCANChannelMode.START, GsUSBCANChannelFlag.NORMAL)
             dev.mode(ch, mode)


### PR DESCRIPTION
Remove useless assignment of "mode" as it is overwritten for each fake channel.