### PR TITLE
github: actions: build: switch to the windows-2025 runner image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15, windows-2022]
+        os: [ubuntu-24.04, macos-15, windows-2025]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Switch to using the windows-2025 (Windows Server 2025) runner image.