### PR TITLE
app: boards: add board overlay for the WeAct Studio USB2CANFDV2

### DIFF
--- a/app/boards/usb2canfdv2_stm32g431xx.overlay
+++ b/app/boards/usb2canfdv2_stm32g431xx.overlay
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Henrik Brix Andersen <henrik@brixandersen.dk>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../app.overlay"
+
+/ {
+	cannectivity: cannectivity {
+		compatible = "cannectivity";
+		timestamp-counter = <&counter2>;
+
+		channel0 {
+			compatible = "cannectivity-channel";
+			can-controller = <&fdcan1>;
+			state-led = <&led_ready>;
+			activity-leds = <&led_rxd &led_txd>;
+		};
+	};
+};
+
+&timers2 {
+	status = "okay";
+	st,prescaler = <159>;
+
+	counter2: counter2 {
+		compatible = "st,stm32-counter";
+		status = "okay";
+	};
+};

--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -28,6 +28,7 @@ tests:
       - lpcxpresso55s16
       - nucleo_h723zg
       - usb2canfdv1
+      - usb2canfdv2
     extra_args:
       - FILE_SUFFIX=debug
   app.cannectivity:
@@ -46,6 +47,7 @@ tests:
       - nucleo_h723zg
       - ucan
       - usb2canfdv1
+      - usb2canfdv2
     build_only: true
   app.cannectivity.sof:
     depends_on:


### PR DESCRIPTION
Add a board overlay for the WeAct Studio USB2CANFDV2 USB to CAN adapter.

This depends on https://github.com/zephyrproject-rtos/zephyr/pull/109791