### PR TITLE
boards: add support for usbcan_iso, usbcanfd solo/dual  and canbridge_g473 adapters

### DIFF
--- a/app/boards/canbridge_g473_stm32g473xx.conf
+++ b/app/boards/canbridge_g473_stm32g473xx.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Oleksii Mamontov <mamontov1@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CANNECTIVITY_USB_SELF_POWERED=n
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/app/boards/canbridge_g473_stm32g473xx.overlay
+++ b/app/boards/canbridge_g473_stm32g473xx.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Oleksii Mamontov <mamontov1@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
+
+/ {
+	cannectivity: cannectivity {
+		compatible = "cannectivity";
+		timestamp-counter = <&counters2>;
+
+		channel0 {
+			compatible = "cannectivity-channel";
+			can-controller = <&fdcan1>;
+			activity-leds = <&led_can1>;
+		};
+ 		channel1 {
+			compatible = "cannectivity-channel";
+			can-controller = <&fdcan2>;
+			activity-leds = <&led_can2>;
+    		};
+		channel2 {
+			compatible = "cannectivity-channel";
+			can-controller = <&fdcan3>;
+			activity-leds = <&led_can3>;
+    		};
+
+	};
+};
+
+&timers2 {
+	st,prescaler = <159>;
+	counters2: counter {
+		status = "okay";
+	};
+};

--- a/app/boards/usbcan_iso_stm32f072xb.conf
+++ b/app/boards/usbcan_iso_stm32f072xb.conf
@@ -1,0 +1,8 @@
+# Copyright (c) 2024-2025 Henrik Brix Andersen <henrik@brixandersen.dk>
+# Copyright (c) 2026 Oleksii Mamontov <mamontov1@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CANNECTIVITY_USB_SELF_POWERED=n
+CONFIG_CAN_FD_MODE=n
+CONFIG_CAN_STM32_BXCAN_MAX_STD_ID_FILTERS=1
+CONFIG_CAN_STM32_BXCAN_MAX_EXT_ID_FILTERS=1

--- a/app/boards/usbcan_iso_stm32f072xb.overlay
+++ b/app/boards/usbcan_iso_stm32f072xb.overlay
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Oleksii Mamontov <mamontov1@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
+
+/ {
+	cannectivity: cannectivity {
+		compatible = "cannectivity";
+		timestamp-counter = <&counter2>;
+
+		channel0 {
+			compatible = "cannectivity-channel";
+			can-controller = <&can1>;
+			activity-leds = <&led_rx &led_tx>;
+		};
+	};
+};
+
+&timers2 {
+	status = "okay";
+	st,prescaler = <47>;
+
+	counter2: counter2 {
+		compatible = "st,stm32-counter";
+		status = "okay";
+	};
+};

--- a/app/boards/usbcanfd_dual_stm32g473xx.conf
+++ b/app/boards/usbcanfd_dual_stm32g473xx.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Oleksii Mamontov <mamontov1@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CANNECTIVITY_USB_SELF_POWERED=n
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/app/boards/usbcanfd_dual_stm32g473xx.overlay
+++ b/app/boards/usbcanfd_dual_stm32g473xx.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Oleksii Mamontov <mamontov1@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
+
+/ {
+	cannectivity: cannectivity {
+		compatible = "cannectivity";
+		timestamp-counter = <&counters2>;
+
+		channel0 {
+			compatible = "cannectivity-channel";
+			can-controller = <&fdcan1>;
+			activity-leds = <&led_rx &led_tx>;
+		};
+    channel1 {
+			compatible = "cannectivity-channel";
+			can-controller = <&fdcan2>;
+			activity-leds = <&led_rx2 &led_tx2>;
+    };
+	};
+};
+
+&timers2 {
+	st,prescaler = <159>;
+	counters2: counter {
+		status = "okay";
+	};
+};

--- a/app/boards/usbcanfd_solo_stm32g431xx.conf
+++ b/app/boards/usbcanfd_solo_stm32g431xx.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Oleksii Mamontov <mamontov1@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CANNECTIVITY_USB_SELF_POWERED=n
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y

--- a/app/boards/usbcanfd_solo_stm32g431xx.overlay
+++ b/app/boards/usbcanfd_solo_stm32g431xx.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Oleksii Mamontov <mamontov1@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include "../app.overlay"
+
+/ {
+	cannectivity: cannectivity {
+		compatible = "cannectivity";
+		timestamp-counter = <&counters2>;
+
+		channel0 {
+			compatible = "cannectivity-channel";
+			can-controller = <&fdcan1>;
+			activity-leds = <&led_rx &led_tx>;
+		};
+	};
+};
+
+&timers2 {
+	st,prescaler = <159>;
+	counters2: counter {
+		status = "okay";
+	};
+};

--- a/app/src/led.c
+++ b/app/src/led.c
@@ -26,6 +26,7 @@ enum led_state {
 	LED_STATE_NORMAL_STARTED,
 	LED_STATE_NORMAL_STOPPED,
 	LED_STATE_IDENTIFY,
+	LED_STATE_BOOT_ANIMATION,
 };
 
 /* LED finite-state machine events */
@@ -382,6 +383,57 @@ static enum smf_state_result led_state_identify_run(void *obj)
 
 	return SMF_EVENT_HANDLED;
 }
+static void led_boot_entry(void *ctx)
+{
+	struct led_ctx *lctx = ctx;
+
+	lctx->identify_ticks = 0; 
+
+	if (lctx->activity_led[LED_ACTIVITY_TX].dev != NULL) {
+		led_on_dt(&lctx->activity_led[LED_ACTIVITY_TX]);
+	}
+	if (lctx->activity_led[LED_ACTIVITY_RX].dev != NULL) {
+		led_off_dt(&lctx->activity_led[LED_ACTIVITY_RX]);
+	}
+}
+
+static enum smf_state_result led_boot_run(void *ctx)
+{
+	struct led_ctx *lctx = ctx;
+
+	if (lctx->event == LED_EVENT_TICK) {
+		lctx->identify_ticks++;
+
+		switch (lctx->identify_ticks) {
+		case 3:
+		case 9:
+			if (lctx->activity_led[LED_ACTIVITY_TX].dev != NULL) {
+				led_off_dt(&lctx->activity_led[LED_ACTIVITY_TX]);
+			}
+			if (lctx->activity_led[LED_ACTIVITY_RX].dev != NULL) {
+				led_on_dt(&lctx->activity_led[LED_ACTIVITY_RX]);
+			}
+			break;
+
+		case 6:
+			if (lctx->activity_led[LED_ACTIVITY_TX].dev != NULL) {
+				led_on_dt(&lctx->activity_led[LED_ACTIVITY_TX]);
+			}
+			if (lctx->activity_led[LED_ACTIVITY_RX].dev != NULL) {
+				led_off_dt(&lctx->activity_led[LED_ACTIVITY_RX]);
+			}
+			break;
+
+		case 12: smf_set_state(SMF_CTX(lctx), &led_states[LED_STATE_NORMAL]);
+			break;
+
+		default:
+      break;
+		}
+	}
+
+	return SMF_EVENT_HANDLED;
+}
 
 /* clang-format off */
 static const struct smf_state led_states[] = {
@@ -405,6 +457,11 @@ static const struct smf_state led_states[] = {
 						NULL,
 						NULL,
 						NULL),
+	[LED_STATE_BOOT_ANIMATION] = SMF_CREATE_STATE(led_boot_entry,
+						      led_boot_run,
+						      NULL,
+						      NULL,
+						      NULL), 						
 };
 /* clang-format on */
 
@@ -580,7 +637,7 @@ int cannectivity_led_init(void)
 			return err;
 		}
 
-		smf_set_initial(SMF_CTX(lctx), &led_states[LED_STATE_NORMAL]);
+		smf_set_initial(SMF_CTX(lctx), &led_states[LED_STATE_BOOT_ANIMATION]);
 	}
 
 	k_timer_start(&led_tick_timer, K_MSEC(LED_TICK_MS), K_MSEC(LED_TICK_MS));


### PR DESCRIPTION
Hello Brix, @henrikbrixandersen ,

This pull request adds support for the following hardware targets:

* usbcan_iso (STM32F072XB)
* usbcanfd_solo (STM32G431XX)
* usbcanfd_dual and canbridge_g473 (STM32G473XX)

+ Adding a boot animation