### PR TITLE
treewide: fix various spelling issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Building the CANnectivity firmware requires a proper Zephyr development environm
 official [Zephyr Getting Started
 Guide](https://docs.zephyrproject.org/latest/getting_started/index.html) to establish one.
 
-Once a proper Zephyr development environment is established, inialize the workspace folder (here
+Once a proper Zephyr development environment is established, initialize the workspace folder (here
 `my-workspace`). This will clone the CANnectivity firmware repository and download the necessary
 Zephyr modules:
 

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -46,7 +46,7 @@ To build CANnectivity with MCUboot integration for USB DFU use :external+zephyr:
 
 .. code-block:: console
 
-   west build -b frdm_k64f/mk64f12 --sysbuild ../custom/cannectivity/app/
+   west build -b frdm_k64f/mk64f12 --sysbuild cannectivity/app/
 
 After building, MCUboot and the CANnectivity firmware can be flashed to the board by running the
 ``west flash`` command.

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -10,7 +10,7 @@ Building and Running
 Building the CANnectivity firmware requires a proper Zephyr development environment. Follow the
 official Zephyr :external+zephyr:ref:`Getting Started Guide <getting_started>` to establish one.
 
-Once a proper Zephyr development environment is established, inialize the workspace folder (here
+Once a proper Zephyr development environment is established, initialize the workspace folder (here
 ``my-workspace``). This will clone the CANnectivity firmware repository and download the necessary
 Zephyr modules:
 

--- a/include/cannectivity/usb/class/gs_usb.h
+++ b/include/cannectivity/usb/class/gs_usb.h
@@ -138,7 +138,7 @@ enum {
  * @{
  */
 
-/** CAN channel supports listen-onlu mode, in which it is not allowed to send dominant bits. */
+/** CAN channel supports listen-only mode, in which it is not allowed to send dominant bits. */
 #define GS_USB_CAN_FEATURE_LISTEN_ONLY              BIT(0)
 /** CAN channel supports in loopback mode, which it receives own frames. */
 #define GS_USB_CAN_FEATURE_LOOP_BACK                BIT(1)
@@ -411,7 +411,7 @@ struct gs_usb_device_bt_const_ext {
 	uint32_t dtseg2_min;
 	/** Data phase time segment 2 maximum value (tq) */
 	uint32_t dtseg2_max;
-	/** Data phasde synchronisation jump width (SJW) maximum value (tq) */
+	/** Data phase synchronisation jump width (SJW) maximum value (tq) */
 	uint32_t dsjw_max;
 	/** Data phase bitrate prescaler minimum value */
 	uint32_t dbrp_min;

--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -446,9 +446,9 @@ static void gs_usb_bittiming_to_can_timing(const struct gs_usb_device_bittiming 
 		result->phase_seg1 = max->phase_seg1;
 	}
 
-	LOG_DBG("request: prop_seg %u, phase_seg1 %u, phase_seq2 %u, sjw %u, brp %u", dbt->prop_seg,
+	LOG_DBG("request: prop_seg %u, phase_seg1 %u, phase_seg2 %u, sjw %u, brp %u", dbt->prop_seg,
 		dbt->phase_seg1, dbt->phase_seg2, dbt->sjw, dbt->brp);
-	LOG_DBG("result: prop_seg %u, phase_seg1 %u, phase_seq2 %u, sjw %u, brp %u",
+	LOG_DBG("result: prop_seg %u, phase_seg1 %u, phase_seg2 %u, sjw %u, brp %u",
 		result->prop_seg, result->phase_seg1, result->phase_seg2, result->sjw,
 		result->prescaler);
 };

--- a/tests/subsys/usb/gs_usb/host/pytest/gs_usb.py
+++ b/tests/subsys/usb/gs_usb/host/pytest/gs_usb.py
@@ -61,7 +61,7 @@ class GsUSBCANChannelFeature(IntFlag):
     """
     Geschwister Schneider USB/CAN protocol CAN channel features.
     """
-    # CAN channel supports listen-onlu mode, in which it is not allowed to send dominant bits.
+    # CAN channel supports listen-only mode, in which it is not allowed to send dominant bits.
     LISTEN_ONLY = 2**0
     # CAN channel supports in loopback mode, which it receives own frames.
     LOOP_BACK = 2**1


### PR DESCRIPTION
- Fix various spelling issues across the tree.
- Remove the assumption on the working directory in example command.