### PR TITLE
usb: device_next: class: gs_usb: add missing net_buf_unref() on return

### DIFF
--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -1070,6 +1070,7 @@ static void gs_usb_can_state_change_callback(const struct device *can_dev, enum 
 		break;
 	case CAN_STATE_STOPPED:
 		/* Not reported */
+		net_buf_unref(buf);
 		return;
 	}
 


### PR DESCRIPTION
Add missing call to net_buf_unref() on early function return.