### PR TITLE
treewide: fix a few minor typos

### DIFF
--- a/app/src/usb.c
+++ b/app/src/usb.c
@@ -343,7 +343,7 @@ void cannectivity_usb_switch_to_dfu_mode(void)
 
 	err = usbd_add_descriptor(&usbd, &product_dfu);
 	if (err != 0) {
-		LOG_ERR("failed to add product descriptor (%d)", err);
+		LOG_ERR("failed to add product descriptor (err %d)", err);
 		return;
 	}
 
@@ -473,7 +473,7 @@ int cannectivity_usb_init(void)
 
 	err = usbd_add_descriptor(&usbd, &product);
 	if (err != 0) {
-		LOG_ERR("failed to add product descriptor (%d)", err);
+		LOG_ERR("failed to add product descriptor (err %d)", err);
 		return err;
 	}
 

--- a/subsys/usb/device_next/class/gs_usb.c
+++ b/subsys/usb/device_next/class/gs_usb.c
@@ -639,7 +639,7 @@ static int gs_usb_request_mode(const struct device *dev, uint16_t ch,
 		channel->started = true;
 		break;
 	default:
-		LOG_ERR("unsupported mode %d requested for channel %u channel",
+		LOG_ERR("unsupported mode %d requested for channel %u",
 			sys_le32_to_cpu(dm->mode), ch);
 		return -ENOTSUP;
 	}

--- a/tests/subsys/usb/gs_usb/host/pytest/gs_usb.py
+++ b/tests/subsys/usb/gs_usb/host/pytest/gs_usb.py
@@ -63,7 +63,7 @@ class GsUSBCANChannelFeature(IntFlag):
     """
     # CAN channel supports listen-only mode, in which it is not allowed to send dominant bits.
     LISTEN_ONLY = 2**0
-    # CAN channel supports in loopback mode, which it receives own frames.
+    # CAN channel supports loopback mode, in which it receives own frames.
     LOOP_BACK = 2**1
     # CAN channel supports triple sampling mode
     TRIPLE_SAMPLE = 2**2
@@ -216,7 +216,7 @@ class GsUSBDeviceBittiming:
     prop_seg: int
     # Phase segment 1 (tq) */
     phase_seg1: int
-    # Phase segment 1 (tq) */
+    # Phase segment 2 (tq) */
     phase_seg2: int
     # Synchronisation jump width (tq) */
     sjw: int


### PR DESCRIPTION
Fix a few minor typos across the tree.