### PR TITLE
github: dependabot: specify commit log prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,19 @@ updates:
     directory: /
     schedule:
       interval: daily
+    commit-message:
+      prefix: "github: "
   # Check for updates to Python packages
   - package-ecosystem: pip
-    directory: /
+    directory: /scripts
     schedule:
       interval: daily
+    commit-message:
+      prefix: "scripts: "
+  # Check for updates to Python packages for the documentation
+  - package-ecosystem: pip
+    directory: /doc
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "doc: "


### PR DESCRIPTION
Specify Git commit log prefixes for the various dependabot-monitored dependencies.