### PR TITLE
Bump minimum required CMake version to v3.28.0

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(cannectivity LANGUAGES C)

--- a/tests/subsys/usb/gs_usb/cxx/CMakeLists.txt
+++ b/tests/subsys/usb/gs_usb/cxx/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(cxx LANGUAGES CXX)

--- a/tests/subsys/usb/gs_usb/host/CMakeLists.txt
+++ b/tests/subsys/usb/gs_usb/host/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(host)
 


### PR DESCRIPTION
Bump the minimum required CMake version to v3.28.0.