### PR TITLE
Remove mention of Linux driver limit

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -65,9 +65,6 @@ config CANNECTIVITY_MAX_CHANNELS
 	  Maximum number of supported Geschwister Schneider USB/CAN (gs_usb) channels. Each channel
 	  represents one CAN controller.
 
-	  The Linux kernel driver supports up to 3 channels. Other drivers may support just one
-	  channel.
-
 configdefault USBD_GS_USB_MAX_CHANNELS
 	default CANNECTIVITY_MAX_CHANNELS
 

--- a/subsys/usb/device_next/class/Kconfig.gs_usb
+++ b/subsys/usb/device_next/class/Kconfig.gs_usb
@@ -26,9 +26,6 @@ config USBD_GS_USB_MAX_CHANNELS
 	  Maximum number of supported Geschwister Schneider USB/CAN (gs_usb) channels. Each channel
 	  represents one CAN controller.
 
-	  The Linux kernel driver supports up to 3 channels. Other drivers may support just one
-	  channel.
-
 config USBD_GS_USB_POOL_SIZE
 	int "Host frame buffer pool size"
 	default 20 if !USBD_GS_USB_COMPATIBILITY_MODE


### PR DESCRIPTION
Remove the note about the Linux kernel gs_usb SocketCAN driver being limited to a maximum of 3 interfaces. This is not true for recent kernel versions.
