### PR TITLE
app: include include/zephyr/sys/clock.h

### DIFF
--- a/app/src/dfu.c
+++ b/app/src/dfu.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/dfu/mcuboot.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/led.h>

--- a/app/src/led.c
+++ b/app/src/led.c
@@ -9,7 +9,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/smf.h>
-#include <zephyr/sys_clock.h>
+#include <zephyr/sys/clock.h>
 
 #include "cannectivity.h"
 


### PR DESCRIPTION
Header file `include/zephyr/sys_clock.h` is deprecated and will be removed someday. Update the application file tree to include `zephyr/sys/clock.h` straight instead of `zephyr/sys_clock.h`.

Related to Zephyr upstream PRs: zephyrproject-rtos/zephyr#112127 and zephyrproject-rtos/zephyr#115656